### PR TITLE
Harden logging and DWG conversion for appV5

### DIFF
--- a/dwg_smoketest.py
+++ b/dwg_smoketest.py
@@ -1,0 +1,25 @@
+import sys
+
+import ezdxf
+
+from appV5 import convert_dwg_to_dxf_2018
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print("Usage: python dwg_smoketest.py <dwg_path> <ODAFileConverter.exe>")
+        sys.exit(1)
+
+    dwg_path = sys.argv[1]
+    oda_exe = sys.argv[2]
+    dxf_path = convert_dwg_to_dxf_2018(dwg_path, oda_exe)
+    print("DXF:", dxf_path)
+
+    doc = ezdxf.readfile(dxf_path)
+    print("Model entities:", len(list(doc.modelspace())))
+    print("Layouts:", list(doc.layouts.names_in_taborder()))
+    print("Units:", doc.header.get("$INSUNITS"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace snapshot logging with a JSON-safe helper to keep LLM debug dumps from crashing when they include methods or other complex objects
- add a lightweight reprice lock and use a debounced scheduler so UI-driven edits cannot trigger re-entrant pricing work
- switch the DWG→DXF conversion to the ODA 2018 helper and include a dwg_smoketest.py script for quick command-line verification

## Testing
- python -m compileall appV5.py dwg_smoketest.py

------
https://chatgpt.com/codex/tasks/task_e_68d734da7f788320a6461472285e9923