### PR TITLE
Load defaults from versioned resources

### DIFF
--- a/cad_quoter/__init__.py
+++ b/cad_quoter/__init__.py
@@ -1,0 +1,1 @@
+"""CAD Quoter package utilities."""

--- a/cad_quoter/config.py
+++ b/cad_quoter/config.py
@@ -1,0 +1,131 @@
+"""Configuration helpers for the CAD quoter application."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+RESOURCE_DIR = Path(__file__).resolve().parent / "resources"
+DEFAULT_VERSION = 1
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration data cannot be loaded or validated."""
+
+
+def _resource_candidates(name: str, version: int) -> list[Path]:
+    base = f"{name}_v{version}"
+    return [
+        RESOURCE_DIR / f"{base}.json",
+        RESOURCE_DIR / f"{base}.yaml",
+        RESOURCE_DIR / f"{base}.yml",
+    ]
+
+
+def _load_from_path(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise ConfigError(f"Configuration file not found: {path}")
+
+    suffix = path.suffix.lower()
+    text = path.read_text(encoding="utf-8")
+
+    if suffix == ".json":
+        try:
+            raw: Any = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ConfigError(f"Malformed JSON in {path.name}: {exc}") from exc
+    elif suffix in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ConfigError(
+                "PyYAML is required to load YAML configuration files"
+            ) from exc
+        try:
+            raw = yaml.safe_load(text)
+        except Exception as exc:
+            raise ConfigError(f"Malformed YAML in {path.name}: {exc}") from exc
+    else:
+        raise ConfigError(f"Unsupported configuration format: {path.suffix}")
+
+    if not isinstance(raw, Mapping):
+        raise ConfigError(f"Configuration root must be an object in {path.name}")
+
+    version = raw.get("version")
+    if version != DEFAULT_VERSION:
+        raise ConfigError(
+            f"Unsupported version in {path.name}: {version!r}; expected {DEFAULT_VERSION}"
+        )
+
+    data = raw.get("data")
+    if not isinstance(data, Mapping):
+        raise ConfigError(f"Configuration 'data' must be an object in {path.name}")
+
+    return dict(data)
+
+
+def load_named_config(name: str, version: int = DEFAULT_VERSION) -> dict[str, Any]:
+    """Load a named configuration bundle from the packaged resources."""
+
+    for candidate in _resource_candidates(name, version):
+        if candidate.exists():
+            return _load_from_path(candidate)
+    raise ConfigError(
+        f"No configuration resource found for '{name}' version {version} in {RESOURCE_DIR}"
+    )
+
+
+def load_default_rates() -> dict[str, float]:
+    """Return the default shop rate configuration."""
+
+    data = load_named_config("rates", DEFAULT_VERSION)
+    return {str(k): float(v) for k, v in data.items()}
+
+
+def load_default_params() -> dict[str, Any]:
+    """Return the default quoting parameter configuration."""
+
+    return load_named_config("params", DEFAULT_VERSION)
+
+
+def save_named_config(
+    data: Mapping[str, Any],
+    path: str | Path,
+    *,
+    version: int = DEFAULT_VERSION,
+    indent: int = 2,
+) -> Path:
+    """Persist configuration data with version metadata.
+
+    The output format is inferred from the destination suffix. JSON is used when
+    the suffix is unrecognised.
+    """
+
+    destination = Path(path)
+    payload: dict[str, Any] = {"version": version, "data": dict(data)}
+
+    suffix = destination.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
+        try:
+            import yaml  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ConfigError(
+                "PyYAML is required to save YAML configuration files"
+            ) from exc
+        text = yaml.safe_dump(payload, sort_keys=False)  # type: ignore[name-defined]
+    else:
+        text = json.dumps(payload, indent=indent, sort_keys=True)
+
+    destination.write_text(text, encoding="utf-8")
+    return destination
+
+
+__all__ = [
+    "ConfigError",
+    "DEFAULT_VERSION",
+    "RESOURCE_DIR",
+    "load_named_config",
+    "load_default_rates",
+    "load_default_params",
+    "save_named_config",
+]

--- a/cad_quoter/resources/params_v1.json
+++ b/cad_quoter/resources/params_v1.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "data": {
+    "OverheadPct": 0.15,
+    "GA_Pct": 0.08,
+    "ContingencyPct": 0.0,
+    "ExpeditePct": 0.0,
+    "MarginPct": 0.35,
+    "InsurancePct": 0.0,
+    "VendorMarkupPct": 0.0,
+    "MinLotCharge": 0.0,
+    "Quantity": 1,
+    "MachineMaxRPM": 8000,
+    "MachineMaxTorqueNm": 70.0,
+    "MachineMaxZTravel_mm": 500.0,
+    "StockCatalog": [
+      {
+        "sku": "plate_steel_0.25_12x12",
+        "material": "steel",
+        "form": "plate",
+        "length_mm": 304.8,
+        "width_mm": 304.8,
+        "thickness_mm": 6.35,
+        "max_weight_kg": 7.0
+      },
+      {
+        "sku": "plate_steel_0.5_12x12",
+        "material": "steel",
+        "form": "plate",
+        "length_mm": 304.8,
+        "width_mm": 304.8,
+        "thickness_mm": 12.7,
+        "max_weight_kg": 14.0
+      },
+      {
+        "sku": "plate_aluminum_0.25_12x24",
+        "material": "aluminum",
+        "form": "plate",
+        "length_mm": 609.6,
+        "width_mm": 304.8,
+        "thickness_mm": 6.35,
+        "max_weight_kg": 12.0
+      },
+      {
+        "sku": "plate_aluminum_0.5_12x24",
+        "material": "aluminum",
+        "form": "plate",
+        "length_mm": 609.6,
+        "width_mm": 304.8,
+        "thickness_mm": 12.7,
+        "max_weight_kg": 24.0
+      }
+    ],
+    "ProgSimpleDim_mm": 80.0,
+    "ProgCapHr": 1.0,
+    "ProgMaxToMillingRatio": 1.5,
+    "OEE_EfficiencyPct": 1.0,
+    "FiveAxisMultiplier": 1.0,
+    "TightToleranceMultiplier": 1.0,
+    "MillingConsumablesPerHr": 4.0,
+    "TurningConsumablesPerHr": 3.0,
+    "EDMConsumablesPerHr": 6.0,
+    "GrindingConsumablesPerHr": 3.0,
+    "InspectionConsumablesPerHr": 1.0,
+    "UtilitiesPerSpindleHr": 2.5,
+    "ConsumablesFlat": 35.0,
+    "MaterialOther": 50.0,
+    "MaterialVendorCSVPath": "",
+    "LLMModelPath": ""
+  }
+}

--- a/cad_quoter/resources/rates_v1.json
+++ b/cad_quoter/resources/rates_v1.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "data": {
+    "ProgrammingRate": 120.0,
+    "MillingRate": 120.0,
+    "DrillingRate": 120.0,
+    "TurningRate": 115.0,
+    "WireEDMRate": 140.0,
+    "SinkerEDMRate": 150.0,
+    "SurfaceGrindRate": 120.0,
+    "ODIDGrindRate": 125.0,
+    "JigGrindRate": 150.0,
+    "LappingRate": 130.0,
+    "InspectionRate": 110.0,
+    "FinishingRate": 100.0,
+    "SawWaterjetRate": 100.0,
+    "FixtureBuildRate": 120.0,
+    "AssemblyRate": 110.0,
+    "EngineerRate": 140.0,
+    "CAMRate": 125.0
+  }
+}


### PR DESCRIPTION
## Summary
- store default rates and parameter bundles as versioned JSON resources under cad_quoter/resources
- add cad_quoter.config helpers for loading and saving versioned configuration data with validation
- update the UI to consume the helpers and surface configuration validation errors to the user

## Testing
- python -m compileall appV5.py cad_quoter

------
https://chatgpt.com/codex/tasks/task_e_68daca8f097083209a917f37c75aa3b0