### PR TITLE
Restore DXF enrichment hook

### DIFF
--- a/tests/integration/test_app_smoke.py
+++ b/tests/integration/test_app_smoke.py
@@ -165,4 +165,20 @@ def test_app_instantiation_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_geo_read_more_hook_is_optional() -> None:
     assert hasattr(appV5, "build_geo_from_dxf")
     hook = appV5.build_geo_from_dxf
-    assert hook is None or callable(hook)
+    assert callable(hook)
+
+
+def test_geo_read_more_hook_override_roundtrip() -> None:
+    captured: list[str] = []
+
+    def _fake_loader(path: str) -> dict:
+        captured.append(path)
+        return {"ok": True, "path": path}
+
+    appV5.set_build_geo_from_dxf_hook(_fake_loader)
+    try:
+        result = appV5.build_geo_from_dxf("/tmp/file.dxf")
+        assert result["ok"] is True
+        assert captured == ["/tmp/file.dxf"]
+    finally:
+        appV5.set_build_geo_from_dxf_hook(None)


### PR DESCRIPTION
## Summary
- restore a callable DXF enrichment helper in `appV5` with an overridable hook
- add a helper to register custom DXF loaders and tighten integration test coverage

## Testing
- pytest tests/integration/test_app_smoke.py::test_geo_read_more_hook_override_roundtrip -q

------
https://chatgpt.com/codex/tasks/task_e_68db5d384530832086bd0c9965fbf282