### PR TITLE
Integrate packaging flat costs into pass-through reporting

### DIFF
--- a/cad_quoter/domain.py
+++ b/cad_quoter/domain.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from cad_quoter.domain_models import QuoteState
 from appV5 import (
     compute_effective_state as _compute_effective_state,
+    effective_to_overrides as _effective_to_overrides,
     merge_effective as _merge_effective,
     reprice_with_effective as _reprice_with_effective,
 )
@@ -13,6 +14,7 @@ __all__ = [
     "QuoteState",
     "merge_effective",
     "compute_effective_state",
+    "effective_to_overrides",
     "reprice_with_effective",
 ]
 
@@ -33,4 +35,10 @@ def reprice_with_effective(*args, **kwargs):  # type: ignore[override]
     """Proxy to :func:`appV5.reprice_with_effective` for test visibility."""
 
     return _reprice_with_effective(*args, **kwargs)
+
+
+def effective_to_overrides(*args, **kwargs):  # type: ignore[override]
+    """Proxy to :func:`appV5.effective_to_overrides` for test visibility."""
+
+    return _effective_to_overrides(*args, **kwargs)
 

--- a/cad_quoter/llm.py
+++ b/cad_quoter/llm.py
@@ -70,6 +70,35 @@ SUGG_TO_EDITOR = {
         str,
         str,
     ),
+    "fixture_build_hr": (
+        "Fixture Build Hours",
+        float,
+        float,
+    ),
+    "in_process_inspection_hr": (
+        "In-Process Inspection Hours",
+        float,
+        float,
+    ),
+    "cmm_minutes": (
+        "CMM Run Time min",
+        float,
+        float,
+    ),
+    "packaging_hours": (
+        "Packaging Labor Hours",
+        float,
+        float,
+    ),
+    "fai_required": (
+        "FAIR Required",
+        lambda flag: 1 if flag else 0,
+        lambda raw: (
+            str(raw).strip().lower() in {"1", "true", "yes", "y"}
+            if raw not in (None, "")
+            else False
+        ),
+    ),
     ("add_pass_through", "Consumables /Hr"): (
         "Consumables /Hr Cost",
         float,


### PR DESCRIPTION
## Summary
- add a comprehensive `build_suggest_payload` helper that assembles GEO, baseline, bounds, and rate signals for the LLM along with sanitized nested data
- overhaul `sanitize_suggestions`, suggestion acceptance, and effective-state plumbing so new fixture/inspection/packaging/CMM fields propagate through overrides, pricing, and UI rows
- expose effective-state helpers through `cad_quoter.domain`, cover them with unit tests, and wire editor mappings for the expanded suggestion schema
- include packaging flat costs in baseline pass-through data and retain baseline values when overrides rewrite packaging charges

## Testing
- pytest -q tests/domain/test_effective_state.py

------
https://chatgpt.com/codex/tasks/task_e_68db6380b1a88320b26ab958d46bc245