### PR TITLE
Document and enforce runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# CAD Quoting Tool
+
+## Setup
+
+1. Create and activate a Python 3.11+ virtual environment.
+2. Install the runtime dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Running the application
+
+After installing the dependencies, run the main application entry point:
+
+```bash
+python appV5.py
+```
+
+If any required packages are missing, the application will exit with an informative error message.

--- a/appV5.py
+++ b/appV5.py
@@ -49,10 +49,32 @@ import textwrap
 import tkinter as tk
 import tkinter.font as tkfont
 import urllib.request
+import importlib.util
 from importlib import import_module
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import cad_quoter.geometry as geometry
+
+
+_REQUIRED_RUNTIME_PACKAGES = {
+    "requests": "requests",
+    "bs4": "beautifulsoup4",
+    "lxml": "lxml",
+}
+
+_missing_runtime_packages = [
+    (module, dist_name)
+    for module, dist_name in _REQUIRED_RUNTIME_PACKAGES.items()
+    if importlib.util.find_spec(module) is None
+]
+
+if _missing_runtime_packages:
+    missing_dists = ", ".join(dist_name for _, dist_name in _missing_runtime_packages)
+    raise ImportError(
+        "Required runtime dependencies are missing. Install them with "
+        "`pip install -r requirements.txt` before launching appV5.py "
+        f"(missing: {missing_dists})."
+    )
 
 from cad_quoter.domain_models import (
     DEFAULT_MATERIAL_DISPLAY,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4
+lxml
+requests


### PR DESCRIPTION
## Summary
- add a root requirements.txt enumerating requests, beautifulsoup4, and lxml
- document installation steps in a new README so appV5 users install dependencies first
- add a startup import check in appV5.py that raises a clear error when dependencies are missing

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68dc0fdfd8588320814d84f4fb0aa602