### PR TITLE
Move Wieland scraper into pricing package

### DIFF
--- a/cad_quoter/pricing/materials.py
+++ b/cad_quoter/pricing/materials.py
@@ -98,7 +98,7 @@ def resolve_material_unit_price(display_name: str, unit: str = "kg") -> tuple[fl
     key = normalize_material_key(display_name)
 
     try:
-        from wieland_scraper import get_live_material_price  # type: ignore
+        from .wieland_scraper import get_live_material_price  # type: ignore
 
         price, source = get_live_material_price(display_name, unit=unit, fallback_usd_per_kg=float("nan"))
         if price is not None and math.isfinite(float(price)):

--- a/cad_quoter/pricing/wieland.py
+++ b/cad_quoter/pricing/wieland.py
@@ -9,7 +9,7 @@ def lookup_price(candidates: Iterable[str]) -> Tuple[float | None, str]:
     """Attempt to look up a USD/kg price using the Wieland scraper."""
 
     try:
-        from wieland_scraper import get_live_material_price_usd_per_kg
+        from .wieland_scraper import get_live_material_price_usd_per_kg
     except Exception:
         return None, ""
 

--- a/cad_quoter/pricing/wieland_scraper.py
+++ b/cad_quoter/pricing/wieland_scraper.py
@@ -15,9 +15,9 @@ Public API:
   get_live_material_price_usd_per_kg(material_key: str, fallback_usd_per_kg=8.0) -> (float, source)
 
 CLI:
-  python wieland_scraper.py --json
-  python wieland_scraper.py --material 6061
-  python wieland_scraper.py --force --debug
+  python -m cad_quoter.pricing.wieland_scraper --json
+  python -m cad_quoter.pricing.wieland_scraper --material 6061
+  python -m cad_quoter.pricing.wieland_scraper --force --debug
 """
 
 from __future__ import annotations

--- a/tests/pricing/test_pricing_utils.py
+++ b/tests/pricing/test_pricing_utils.py
@@ -17,9 +17,9 @@ def test_price_value_to_per_gram_converts_common_units() -> None:
 
 
 def test_resolve_material_unit_price_prefers_wieland(monkeypatch: pytest.MonkeyPatch) -> None:
-    module = types.ModuleType("wieland_scraper")
+    module = types.ModuleType("cad_quoter.pricing.wieland_scraper")
     module.get_live_material_price = lambda *args, **kwargs: (17.5, "wieland-live")
-    monkeypatch.setitem(sys.modules, "wieland_scraper", module)
+    monkeypatch.setitem(sys.modules, "cad_quoter.pricing.wieland_scraper", module)
 
     price, source = pricing.resolve_material_unit_price("6061 aluminum", unit="kg")
     assert price == pytest.approx(17.5)
@@ -29,9 +29,9 @@ def test_resolve_material_unit_price_prefers_wieland(monkeypatch: pytest.MonkeyP
 def test_resolve_material_unit_price_falls_back_to_csv(
     monkeypatch: pytest.MonkeyPatch, sample_pricing_table: dict
 ) -> None:
-    module = types.ModuleType("wieland_scraper")
+    module = types.ModuleType("cad_quoter.pricing.wieland_scraper")
     module.get_live_material_price = lambda *args, **kwargs: (None, "wieland-offline")
-    monkeypatch.setitem(sys.modules, "wieland_scraper", module)
+    monkeypatch.setitem(sys.modules, "cad_quoter.pricing.wieland_scraper", module)
 
     monkeypatch.setattr(pricing, "load_backup_prices_csv", lambda path=None: sample_pricing_table)
 


### PR DESCRIPTION
## Summary
- move the Wieland scraper into the cad_quoter.pricing package so it is bundled with the library
- update pricing utilities to import the scraper via relative paths
- adjust pricing tests to monkeypatch the new module location

## Testing
- pytest tests/pricing/test_pricing_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dc0fdd3eb48320825bc5dfeaf505aa