### PR TITLE
Handle non-numeric rows in vendor CSV provider

### DIFF
--- a/cad_quoter/pricing/vendor_csv.py
+++ b/cad_quoter/pricing/vendor_csv.py
@@ -1,4 +1,8 @@
-"""Provider that sources prices from a user-supplied CSV file."""
+"""Provider that sources prices from a user-supplied CSV file.
+
+The CSV may include an optional header row. Each populated row should
+contain a symbol followed by a numeric USD-per-kilogram value.
+"""
 from __future__ import annotations
 
 import csv
@@ -29,7 +33,11 @@ class VendorCSV(PriceProvider):
                     if not row:
                         continue
                     symbol, usd_per_kg, *_ = row
-                    self._rows[symbol.strip().upper()] = float(usd_per_kg)
+                    try:
+                        price = float(usd_per_kg)
+                    except ValueError:
+                        continue
+                    self._rows[symbol.strip().upper()] = price
 
     def get(self, symbol: str) -> tuple[float, str]:
         self._load()

--- a/tests/pricing/test_vendor_csv.py
+++ b/tests/pricing/test_vendor_csv.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from cad_quoter.pricing.vendor_csv import VendorCSV
+
+
+def test_vendor_csv_skips_header_and_notes(tmp_path: Path) -> None:
+    csv_content = """symbol,usd_per_kg\n6061,5.5\nnotes,not a number\n7075,8.9\n"""
+    csv_file = tmp_path / "vendor_prices.csv"
+    csv_file.write_text(csv_content, encoding="utf-8")
+
+    provider = VendorCSV(str(csv_file))
+    provider._load()
+
+    assert provider._rows == {"6061": 5.5, "7075": 8.9}


### PR DESCRIPTION
## Summary
- document the expected vendor CSV format for symbol and USD/kg columns
- guard the vendor CSV loader against header or note rows with non-numeric prices
- add a regression test ensuring only numeric rows populate the provider cache

## Testing
- pytest tests/pricing/test_vendor_csv.py *(fails: missing requests, beautifulsoup4, lxml runtime dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1f85b3bc832089e11e377ea2357e