### PR TITLE
Ensure material pricing uses resolver fallbacks

### DIFF
--- a/tests/app/test_editor_helpers.py
+++ b/tests/app/test_editor_helpers.py
@@ -1,0 +1,29 @@
+import appV5
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+    def set(self, value):
+        self._value = value
+
+
+def test_update_material_price_field_uses_fallback(monkeypatch):
+    choice_var = DummyVar("Custom Alloy")
+    price_var = DummyVar("")
+    material_lookup = {}
+
+    monkeypatch.setattr(
+        appV5,
+        "_resolve_material_unit_price",
+        lambda choice, unit="kg": (5.5, "backup_csv:material_price_backup.csv"),
+    )
+
+    changed = appV5._update_material_price_field(choice_var, price_var, material_lookup)
+
+    assert changed is True
+    assert price_var.get() == "0.0055"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import types
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 from typing import Callable, Dict
 
@@ -9,6 +10,31 @@ import pytest
 
 
 # ----- stub heavy optional dependencies before importing application code -----
+
+
+def _install_runtime_dependency_stubs() -> None:
+    if "requests" not in sys.modules:
+        requests_stub = types.ModuleType("requests")
+        requests_stub.__spec__ = ModuleSpec("requests", loader=None)
+        sys.modules["requests"] = requests_stub
+
+    if "bs4" not in sys.modules:
+        bs4_stub = types.ModuleType("bs4")
+        bs4_stub.__spec__ = ModuleSpec("bs4", loader=None)
+
+        class _BeautifulSoup:  # pragma: no cover - behaviour not needed in tests
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        bs4_stub.BeautifulSoup = _BeautifulSoup
+        sys.modules["bs4"] = bs4_stub
+
+    if "lxml" not in sys.modules:
+        lxml_stub = types.ModuleType("lxml")
+        lxml_stub.__spec__ = ModuleSpec("lxml", loader=None)
+        sys.modules["lxml"] = lxml_stub
+
 
 def _install_ocp_stubs() -> None:
     if "OCP" in sys.modules:
@@ -290,12 +316,22 @@ def _install_pandas_stub() -> None:
             for idx, row in enumerate(self._rows):
                 yield idx, row
 
+    import csv
+
     pandas_stub = types.ModuleType("pandas")
     pandas_stub.DataFrame = DataFrame
     pandas_stub.Series = Series
+
+    def read_csv(path):
+        with open(path, newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            return DataFrame(reader)
+
+    pandas_stub.read_csv = read_csv
     sys.modules["pandas"] = pandas_stub
 
 
+_install_runtime_dependency_stubs()
 _install_ocp_stubs()
 _install_llama_stub()
 _install_pandas_stub()

--- a/tests/pricing/test_material_cost_fallback.py
+++ b/tests/pricing/test_material_cost_fallback.py
@@ -1,0 +1,36 @@
+import pytest
+
+import appV5
+
+
+class _FailingPricingEngine:
+    def get_usd_per_kg(self, *args, **kwargs):
+        raise RuntimeError("providers unavailable")
+
+
+def test_compute_material_cost_uses_csv_fallback(monkeypatch):
+    monkeypatch.setattr(appV5, "lookup_wieland_price", lambda _c: (None, ""))
+
+    mass_kg = 2.0
+    scrap = 0.0
+    overrides = {}
+    vendor_csv = None
+
+    material_name = "Aluminum 6061"
+    cost, detail = appV5.compute_material_cost(
+        material_name,
+        mass_kg,
+        scrap,
+        overrides,
+        vendor_csv,
+        pricing=_FailingPricingEngine(),
+    )
+
+    expected_unit_price, expected_source = appV5._resolve_material_unit_price(
+        material_name,
+        unit="kg",
+    )
+    assert detail["unit_price_usd_per_kg"] == pytest.approx(expected_unit_price)
+    assert detail["source"].startswith("backup_csv")
+    assert detail["source"].endswith(appV5.BACKUP_CSV_NAME)
+    assert cost == pytest.approx(mass_kg * expected_unit_price)


### PR DESCRIPTION
## Summary
- update material pricing fallbacks to consistently use `_resolve_material_unit_price`, including the 2D plate override and editor helper
- add reusable helper logic for populating the material price field when resolver data is needed
- stub runtime-only dependencies in tests and add regression/UI tests to cover fallback pricing behaviour

## Testing
- pytest tests/pricing/test_material_cost_fallback.py tests/app/test_editor_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dc1f8496c48320bb865f6f9fcfdd28