### PR TITLE
Surface hole metrics from GEO defaults

### DIFF
--- a/tests/app/test_editor_helpers.py
+++ b/tests/app/test_editor_helpers.py
@@ -12,6 +12,19 @@ class DummyVar:
         self._value = value
 
 
+def _make_stub_app():
+    app = appV5.App.__new__(appV5.App)
+    app.editor_vars = {
+        "Hole Count (override)": DummyVar(""),
+        "Avg Hole Diameter (mm)": DummyVar(""),
+    }
+    app.editor_value_sources = {}
+    app.editor_label_widgets = {}
+    app.editor_label_base = {}
+    app._editor_set_depth = 0
+    return app
+
+
 def test_update_material_price_field_uses_fallback(monkeypatch):
     choice_var = DummyVar("Custom Alloy")
     price_var = DummyVar("")
@@ -27,3 +40,32 @@ def test_update_material_price_field_uses_fallback(monkeypatch):
 
     assert changed is True
     assert price_var.get() == "0.0055"
+
+
+def test_apply_geo_defaults_populates_hole_fields():
+    app = _make_stub_app()
+
+    geo = {
+        "hole_count": 6,
+        "hole_diams_mm": [3.0, 5.0, 4.0],
+        "hole_bins": {2.0: 10},
+        "feature_counts": {"hole_count": 6},
+    }
+
+    app._apply_geo_defaults(geo)
+
+    assert app.editor_vars["Hole Count (override)"].get() == "6.000"
+    assert app.editor_vars["Avg Hole Diameter (mm)"].get() == "4.000"
+
+
+def test_apply_geo_defaults_falls_back_to_hole_bins():
+    app = _make_stub_app()
+
+    geo = {
+        "hole_bins": {3.0: 2, 5.0: 4},
+    }
+
+    app._apply_geo_defaults(geo)
+
+    assert app.editor_vars["Hole Count (override)"].get() == "6.000"
+    assert app.editor_vars["Avg Hole Diameter (mm)"].get() == "4.333"


### PR DESCRIPTION
## Summary
- surface hole count and average diameter from GEO data, considering nested count/bin sources
- populate the editor hole count and diameter defaults only when user overrides are absent
- add regression tests that exercise direct diameter lists and hole-bin fallbacks

## Testing
- pytest tests/app/test_editor_helpers.py *(fails: ImportError while loading tests/conftest.py: NameError: _install_runtime_dep_stubs is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68dc342dc16c832097c995f368c2b7d2