### PR TITLE
Autofill override fields using GEO data

### DIFF
--- a/tests/app/test_editor_helpers.py
+++ b/tests/app/test_editor_helpers.py
@@ -1,4 +1,5 @@
 import appV5
+import pytest
 
 
 class DummyVar:
@@ -27,3 +28,48 @@ def test_update_material_price_field_uses_fallback(monkeypatch):
 
     assert changed is True
     assert price_var.get() == "0.0055"
+
+
+def test_infer_geo_override_defaults_basic_fields():
+    geo = {
+        "plate_len_in": 10.0,
+        "plate_wid_in": 5.0,
+        "thickness_mm": 12.7,
+        "hole_diams_mm": [10.0, 5.0, 5.0],
+        "tap_qty": 4,
+        "cbore_qty": 2,
+        "csk_qty": 1,
+        "material": "Aluminum 6061",
+        "fai_required": True,
+        "setups": 3,
+    }
+
+    defaults = appV5.infer_geo_override_defaults(geo)
+
+    assert defaults["Plate Length (in)"] == pytest.approx(10.0)
+    assert defaults["Plate Width (in)"] == pytest.approx(5.0)
+    assert defaults["Thickness (in)"] == pytest.approx(12.7 / 25.4)
+    assert defaults["Number of Milling Setups"] == 3
+    assert defaults["Material"] == "Aluminum 6061"
+    assert defaults["FAIR Required"] == 1
+    assert defaults["Tap Qty (LLM/GEO)"] == 4
+    assert defaults["Cbore Qty (LLM/GEO)"] == 2
+    assert defaults["Csk Qty (LLM/GEO)"] == 1
+    assert defaults["Hole Count (override)"] == 3
+    assert defaults["Avg Hole Diameter (mm)"] == pytest.approx((10.0 + 5.0 + 5.0) / 3.0)
+
+
+def test_infer_geo_override_defaults_uses_bins_and_back_face():
+    geo = {
+        "meta": {"needs_back_face": True},
+        "derived": {"hole_bins": {"0.25 in": 4, "6 mm": 2}},
+        "scrap_pct": 0.08,
+    }
+
+    defaults = appV5.infer_geo_override_defaults(geo)
+
+    expected_avg = ((0.25 * 25.4) * 4 + 6.0 * 2) / 6.0
+    assert defaults["Hole Count (override)"] == 6
+    assert defaults["Avg Hole Diameter (mm)"] == pytest.approx(expected_avg)
+    assert defaults["Number of Milling Setups"] == 2
+    assert defaults["Scrap Percent (%)"] == pytest.approx(8.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,9 @@ def _install_runtime_dependency_stubs() -> None:
         sys.modules["lxml"] = lxml_stub
 
 
+_install_runtime_dep_stubs = _install_runtime_dependency_stubs
+
+
 def _install_ocp_stubs() -> None:
     if "OCP" in sys.modules:
         return


### PR DESCRIPTION
## Summary
- add GEO parsing helpers that derive plate, thickness, hole, and feature defaults for the override editor
- populate the quote editor using the derived defaults, including respecting GEO-sourced materials when the field is untouched
- expand editor helper tests (and supporting stubs) to cover the new GEO autofill behavior

## Testing
- pytest tests/app/test_editor_helpers.py


------
https://chatgpt.com/codex/tasks/task_e_68dc32e48dd88320b95d6ec98c87e29d