### PR TITLE
Fix quote editor dropdown and checkbox rendering

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -12840,15 +12840,106 @@ class App(tk.Tk):
             )
 
 
+        dtype_col_name = next(
+            (
+                col
+                for col in df.columns
+                if str(col).strip().lower() == "data type / input method"
+            ),
+            "Data Type / Input Method",
+        )
+        value_col_name = next(
+            (
+                col
+                for col in df.columns
+                if str(col).strip().lower() == "example values / options"
+            ),
+            "Example Values / Options",
+        )
+
+        def _normalize_dtype(raw: str) -> str:
+            lowered = str(raw or "").lower()
+            return re.sub(r"\s+", " ", lowered).strip()
+
+        bool_pair_re = re.compile(
+            r"^\s*(true|false|yes|no|on|off)\s*(?:/|\||,|\s+or\s+)\s*(true|false|yes|no|on|off)\s*$",
+            re.IGNORECASE,
+        )
+
+        def _split_options(text: str) -> list[str]:
+            if not text:
+                return []
+            if bool_pair_re.match(text):
+                parts = re.split(r"[/|,]|\s+or\s+", text, flags=re.IGNORECASE)
+            else:
+                parts = re.split(r"[,\n;|]+", text)
+            return [p.strip() for p in parts if p and p.strip()]
+
+        truthy_tokens = {"true", "1", "yes", "y", "on"}
+        falsy_tokens = {"false", "0", "no", "n", "off"}
+
+        def _looks_like_bool_options(options: list[str]) -> bool:
+            if not options or len(options) > 4:
+                return False
+            normalized = {opt.lower() for opt in options}
+            return bool(normalized & truthy_tokens) and bool(normalized & falsy_tokens)
+
+        def _is_numeric_token(token: str) -> bool:
+            try:
+                float(token.replace(",", ""))
+                return True
+            except Exception:
+                return False
+
         for _, row_data in df.iterrows():
             item_name = str(row_data["Item"])
             normalized_name = normalize_item(item_name)
             if normalized_name in skip_items:
                 continue
-            label_widget = ttk.Label(quote_frame, text=item_name, wraplength=400)
-            label_widget.grid(row=row_index, column=0, sticky="w", padx=5, pady=2)
-            initial_raw = row_data["Example Values / Options"]
-            initial_value = str(initial_raw) if initial_raw is not None else ""
+
+            dtype_raw = _normalize_dtype(row_data.get(dtype_col_name, ""))
+            initial_raw = row_data.get(value_col_name, "")
+            initial_value = "" if pd.isna(initial_raw) else str(initial_raw)
+            option_candidates = _split_options(initial_value)
+            looks_like_bool = _looks_like_bool_options(option_candidates)
+            is_checkbox = "checkbox" in dtype_raw or looks_like_bool
+            is_dropdown = "dropdown" in dtype_raw or "select" in dtype_raw
+            is_formula_like = "lookup" in dtype_raw or "calculated" in dtype_raw
+            if not is_dropdown and not is_checkbox and not is_formula_like:
+                has_formula_chars = bool(re.search(r"[=*()+{}]", initial_value))
+                non_numeric_options = [opt for opt in option_candidates if not _is_numeric_token(opt)]
+                if non_numeric_options and len(option_candidates) >= 2 and not has_formula_chars:
+                    is_dropdown = True
+
+            row_container = ttk.Frame(quote_frame)
+            row_container.grid(row=row_index, column=0, columnspan=2, sticky="ew", padx=5, pady=4)
+            row_container.grid_columnconfigure(1, weight=1)
+
+            label_widget = ttk.Label(row_container, text=item_name, wraplength=400)
+            label_widget.grid(row=0, column=0, sticky="w", padx=(0, 6))
+
+            control_row = 0
+            info_row = 1
+            info_labels: list[ttk.Label] = []
+
+            control_container = ttk.Frame(row_container)
+            control_container.grid(row=control_row, column=1, sticky="ew", padx=5)
+            control_container.grid_columnconfigure(0, weight=1)
+            control_container.grid_columnconfigure(1, weight=0)
+
+            def _add_info_label(text: str) -> None:
+                if not text:
+                    return
+                label = ttk.Label(row_container, text=text, wraplength=360, foreground="#555555")
+                label.grid(
+                    row=len(info_labels) + info_row,
+                    column=1,
+                    columnspan=2,
+                    sticky="w",
+                    pady=(2, 0),
+                )
+                info_labels.append(label)
+
             if normalized_name in {"material"}:
                 var = tk.StringVar(value=self.default_material_display)
                 if initial_value:
@@ -12863,29 +12954,78 @@ class App(tk.Tk):
                             var.set(display)
                         break
                 combo = ttk.Combobox(
-                    quote_frame,
+                    control_container,
                     textvariable=var,
                     values=MATERIAL_DROPDOWN_OPTIONS,
                     width=32,
                 )
-                combo.grid(row=row_index, column=1, sticky="w", padx=5, pady=2)
+                combo.grid(row=0, column=0, sticky="ew")
+                manual_entry = ttk.Entry(control_container, textvariable=var, width=14)
+                manual_entry.grid(row=0, column=1, sticky="w", padx=(6, 0))
                 combo.bind("<<ComboboxSelected>>", update_material_price)
                 var.trace_add("write", update_material_price)
                 material_choice_var = var
                 self.var_material = var
                 self.quote_vars[item_name] = var
                 self._register_editor_field(item_name, var, label_widget)
-            elif re.search(r"(Material\s*Price.*(per\s*gram|per\s*g|/g)|Unit\s*Price\s*/\s*g)", item_name, flags=re.IGNORECASE):
+            elif re.search(
+                r"(Material\s*Price.*(per\s*gram|per\s*g|/g)|Unit\s*Price\s*/\s*g)",
+                item_name,
+                flags=re.IGNORECASE,
+            ):
                 var = tk.StringVar(value=initial_value)
-                ttk.Entry(quote_frame, textvariable=var, width=30).grid(row=row_index, column=1, sticky="w", padx=5, pady=2)
+                ttk.Entry(control_container, textvariable=var, width=30).grid(row=0, column=0, sticky="w")
                 material_price_var = var
+                self.quote_vars[item_name] = var
+                self._register_editor_field(item_name, var, label_widget)
+            elif is_dropdown:
+                options = option_candidates or ([initial_value] if initial_value else [])
+                selected = initial_value
+                if options:
+                    if selected not in options:
+                        selected = options[0]
+                var = tk.StringVar(value=selected)
+                combo = ttk.Combobox(
+                    control_container,
+                    textvariable=var,
+                    values=options,
+                    width=28,
+                )
+                combo.grid(row=0, column=0, sticky="ew")
+                manual_entry = ttk.Entry(control_container, textvariable=var, width=14)
+                manual_entry.grid(row=0, column=1, sticky="w", padx=(6, 0))
+                self.quote_vars[item_name] = var
+                self._register_editor_field(item_name, var, label_widget)
+            elif is_checkbox:
+                initial_bool = str(initial_value).strip().lower() in truthy_tokens
+                var = tk.StringVar(value="True" if initial_bool else "False")
+                ttk.Checkbutton(
+                    control_container,
+                    variable=var,
+                    onvalue="True",
+                    offvalue="False",
+                ).grid(row=0, column=0, sticky="w")
                 self.quote_vars[item_name] = var
                 self._register_editor_field(item_name, var, label_widget)
             else:
                 var = tk.StringVar(value=initial_value)
-                ttk.Entry(quote_frame, textvariable=var, width=30).grid(row=row_index, column=1, sticky="w", padx=5, pady=2)
+                ttk.Entry(control_container, textvariable=var, width=30).grid(row=0, column=0, sticky="w")
                 self.quote_vars[item_name] = var
                 self._register_editor_field(item_name, var, label_widget)
+
+                if "lookup" in dtype_raw or "calculated" in dtype_raw:
+                    base_text = initial_value.strip()
+                    if base_text:
+                        _add_info_label(f"Based on: {base_text}")
+
+            why_text = str(row_data.get("Why it Matters", "") or "").strip()
+            if why_text:
+                _add_info_label(why_text)
+
+            swing_text = str(row_data.get("Typical Price Swing*", "") or "").strip()
+            if swing_text:
+                _add_info_label(f"Typical swing: {swing_text}")
+
             row_index += 1
 
         if material_choice_var is not None and material_price_var is not None:


### PR DESCRIPTION
## Summary
- detect dropdown and checkbox rows more robustly by normalizing metadata and falling back to option heuristics
- render comboboxes with paired text entries and install checkbuttons so quote variables expose the expected controls
- keep lookup/calculated fields as editable entries while surfacing their source details below each row

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc7d7bf9b08320a6ac7f3477b6ee67