### PR TITLE
Add project management and toolmaker support buckets

### DIFF
--- a/cad_quoter/resources/rates_v1.json
+++ b/cad_quoter/resources/rates_v1.json
@@ -17,6 +17,8 @@
     "FixtureBuildRate": 120.0,
     "AssemblyRate": 110.0,
     "EngineerRate": 140.0,
+    "ProjectManagementRate": 135.0,
+    "ToolmakerSupportRate": 125.0,
     "CAMRate": 125.0
   }
 }

--- a/tests/pricing/test_project_and_toolmaker_costs.py
+++ b/tests/pricing/test_project_and_toolmaker_costs.py
@@ -1,0 +1,51 @@
+import pandas as pd
+
+import appV5
+
+
+def test_project_management_and_toolmaker_rows_rendered() -> None:
+    df = pd.DataFrame(
+        [
+            {"Item": "Qty", "Example Values / Options": 1, "Data Type / Input Method": "number"},
+            {
+                "Item": "Material Name",
+                "Example Values / Options": "6061-T6 Aluminum",
+                "Data Type / Input Method": "text",
+            },
+            {
+                "Item": "Net Volume (cm^3)",
+                "Example Values / Options": 50,
+                "Data Type / Input Method": "number",
+            },
+            {
+                "Item": "Thickness (in)",
+                "Example Values / Options": 1.0,
+                "Data Type / Input Method": "number",
+            },
+            {
+                "Item": "Project Management Hours",
+                "Example Values / Options": 2.0,
+                "Data Type / Input Method": "number",
+            },
+            {
+                "Item": "Tool & Die Maker Hours",
+                "Example Values / Options": 1.5,
+                "Data Type / Input Method": "number",
+            },
+        ]
+    )
+
+    result = appV5.compute_quote_from_df(df, llm_enabled=False)
+    breakdown = result["breakdown"]
+    process_costs = breakdown["process_costs"]
+    project_meta = breakdown["process_meta"]["project_management"]
+    toolmaker_meta = breakdown["process_meta"]["toolmaker_support"]
+
+    assert project_meta["hr"] > 0, breakdown
+    assert toolmaker_meta["hr"] > 0, breakdown
+    assert process_costs["project_management"] > 0, breakdown
+    assert process_costs["toolmaker_support"] > 0, breakdown
+
+    rendered = appV5.render_quote(result, currency="$")
+    assert "Project Management" in rendered
+    assert "Toolmaker Support" in rendered


### PR DESCRIPTION
## Summary
- extend the estimator patterns and regex helpers so project management and toolmaker labels are recognised and no longer filtered out
- capture project management and toolmaker support hours/costs with configurable rates and include them in the process cost/meta breakdown
- update the pandas test stub and add coverage to confirm the new buckets appear in rendered quotes

## Testing
- `pytest tests/pricing`


------
https://chatgpt.com/codex/tasks/task_e_68dd4877f0ec8320ac1bc1d5b79db186