### PR TITLE
Update Wieland scraper for new site structure

### DIFF
--- a/cad_quoter/pricing/wieland.py
+++ b/cad_quoter/pricing/wieland.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 from typing import Iterable, Tuple
 import math
 
+from cad_quoter.config import logger
+
 
 def lookup_price(candidates: Iterable[str]) -> Tuple[float | None, str]:
     """Attempt to look up a USD/kg price using the Wieland scraper."""
 
     try:
         from .wieland_scraper import get_live_material_price_usd_per_kg
-    except Exception:
+    except Exception as exc:  # pragma: no cover - exercised via integration
+        logger.exception("Unable to import Wieland scraper: %s", exc)
         return None, ""
 
     for candidate in candidates:
@@ -19,7 +22,8 @@ def lookup_price(candidates: Iterable[str]) -> Tuple[float | None, str]:
             continue
         try:
             price, source = get_live_material_price_usd_per_kg(label, fallback_usd_per_kg=-1.0)
-        except Exception:
+        except Exception as exc:
+            logger.exception("Wieland lookup failed for %s: %s", label, exc)
             continue
         if not isinstance(price, (int, float)):
             continue

--- a/cad_quoter/pricing/wieland_scraper.py
+++ b/cad_quoter/pricing/wieland_scraper.py
@@ -30,13 +30,19 @@ import re
 import sys
 import time
 import tempfile
+import urllib.request
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple, Optional, List
+from html import unescape as html_unescape
+from typing import Any, Dict, Iterable, Tuple, Optional, List
+
+import ssl
 
 from cad_quoter.config import configure_logging, logger
 
-import requests
-from bs4 import BeautifulSoup
+try:  # pragma: no cover - optional dependency in production
+    from bs4 import BeautifulSoup  # type: ignore
+except Exception:  # pragma: no cover - fallback without bs4
+    BeautifulSoup = None  # type: ignore
 
 
 # --------------------------------- config ------------------------------------
@@ -44,7 +50,7 @@ from bs4 import BeautifulSoup
 WIELAND_URL = "https://www.wieland.com/en/resources/metal-information"
 
 CACHE_TTL_S = int(os.getenv("WIELAND_CACHE_TTL_S", 60 * 30))         # 30 minutes
-REQUEST_TIMEOUT_S = int(os.getenv("WIELAND_REQ_TIMEOUT_S", 15))      # seconds
+REQUEST_TIMEOUT_S = int(os.getenv("WIELAND_REQ_TIMEOUT_S", 30))      # seconds
 USER_AGENT = os.getenv(
     "WIELAND_USER_AGENT",
     "Mozilla/5.0 (compatible; QuoterBot/1.0; +https://example.local/quote-tool)"
@@ -52,7 +58,7 @@ USER_AGENT = os.getenv(
 
 # --------------------------------- globals -----------------------------------
 
-_NUM_RE = re.compile(r"[+-]?\d+(?:[.,]\d+)?")
+_NUM_RE = re.compile(r"[+-]?(?:\d[\d\s\u202f\u00a0.,']*)")
 _MEM_CACHE: Dict[str, Tuple[float, Dict[str, Any]]] = {}  # key -> (ts, data)
 
 
@@ -76,15 +82,53 @@ def _usdkg_to_usdlb(x: float) -> float:
 
 
 def _to_float(s: str) -> float:
-    """Parse first numeric token from a string (handles 9,900.00)."""
+    """Parse first numeric token from a string (handles localized formats)."""
+
     if s is None:
         return math.nan
-    m = _NUM_RE.search(s.replace("\xa0", " ").strip())
-    if not m:
+
+    token_match = _NUM_RE.search(str(s).strip())
+    if not token_match:
         return math.nan
-    t = m.group(0).replace(",", "")
+
+    token = token_match.group(0)
+
+    # Normalize common thousands separators (space, thin space, apostrophe)
+    token = (
+        token.replace("\u202f", "")
+        .replace("\xa0", "")
+        .replace(" ", "")
+        .replace("'", "")
+    )
+
+    token = token.replace("−", "-")  # minus sign
+
+    # Determine decimal separator heuristically
+    if "," in token and "." in token:
+        if token.rfind(",") > token.rfind("."):
+            decimal_sep, thousands_sep = ",", "."
+        else:
+            decimal_sep, thousands_sep = ".", ","
+    elif token.count(",") >= 1:
+        # If comma present and looks like thousands separator (e.g., 1,234)
+        last = token.rfind(",")
+        decimals = len(token) - last - 1
+        if decimals in (3, 0):
+            decimal_sep, thousands_sep = None, ","
+        else:
+            decimal_sep, thousands_sep = ",", None
+    elif token.count(".") >= 2:
+        decimal_sep, thousands_sep = ".", None
+    else:
+        decimal_sep, thousands_sep = ".", None if "." in token else None
+
+    if thousands_sep:
+        token = token.replace(thousands_sep, "")
+    if decimal_sep and decimal_sep != ".":
+        token = token.replace(decimal_sep, ".")
+
     try:
-        return float(t)
+        return float(token)
     except Exception:
         return math.nan
 
@@ -116,20 +160,227 @@ def _write_temp_cache(data: Dict[str, Any]) -> None:
         pass
 
 
-def _get_soup(debug: bool = False) -> BeautifulSoup:
-    headers = {"User-Agent": USER_AGENT}
-    r = requests.get(WIELAND_URL, headers=headers, timeout=REQUEST_TIMEOUT_S)
-    r.raise_for_status()
+class SoupDocument:
+    """Small wrapper that mimics a subset of BeautifulSoup we rely on."""
+
+    __slots__ = ("html", "_soup", "_json_cache")
+
+    def __init__(self, html: str) -> None:
+        self.html = html
+        self._soup = BeautifulSoup(html, "lxml") if BeautifulSoup else None
+        self._json_cache: Optional[List[Any]] = None
+
+    def get_text(self, separator: str = "", strip: bool = False) -> str:
+        if self._soup is not None:
+            try:
+                return self._soup.get_text(separator, strip=strip)
+            except AttributeError:
+                pass
+        text = re.sub(r"<[^>]+>", " ", self.html)
+        if strip:
+            text = " ".join(part for part in text.split() if part)
+        return text if separator == "" else separator.join(text.split())
+
+    def find_all(self, *args, **kwargs):  # pragma: no cover - rarely used without bs4
+        if self._soup is not None:
+            try:
+                return self._soup.find_all(*args, **kwargs)
+            except AttributeError:
+                pass
+        return []
+
+
+def _fetch_html() -> str:
+    context = ssl.create_default_context()
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Connection": "close",
+    }
+    request = urllib.request.Request(WIELAND_URL, headers=headers)
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S, context=context) as resp:  # type: ignore[arg-type]
+        charset = resp.headers.get_content_charset() or "utf-8"
+        return resp.read().decode(charset, errors="replace")
+
+
+def _get_soup(debug: bool = False) -> SoupDocument:
+    html = _fetch_html()
     if debug:
         snap = os.path.join(tempfile.gettempdir(), "wieland_snapshot.html")
         with open(snap, "w", encoding="utf-8") as f:
-            f.write(r.text)
+            f.write(html)
         logger.debug("Saved HTML snapshot to %s", snap)
-    return BeautifulSoup(r.text, "lxml")
+    return SoupDocument(html)
 
 
 def _block_text(el) -> str:
     return " ".join(el.stripped_strings)
+
+
+_JSON_PATTERNS = [
+    re.compile(r"<script[^>]+id=\"__NEXT_DATA__\"[^>]*>\s*(\{.*?\})\s*</script>", re.S | re.I),
+    re.compile(r"window\.__NUXT__\s*=\s*(\{.*?\});", re.S | re.I),
+    re.compile(r"data-props=\"(\{.*?\})\"", re.S | re.I),
+    re.compile(r"<script[^>]+type=\"application/json\"[^>]*>\s*(\{.*?\})\s*</script>", re.S | re.I),
+]
+
+
+def _extract_json_payloads(doc: SoupDocument) -> List[Any]:
+    if doc._json_cache is not None:
+        return doc._json_cache
+
+    payloads: List[Any] = []
+    html = doc.html
+    for pattern in _JSON_PATTERNS:
+        for match in pattern.finditer(html):
+            blob = html_unescape(match.group(1))
+            blob = blob.strip()
+            if blob.endswith(";"):
+                blob = blob[:-1]
+            if not blob:
+                continue
+            try:
+                payloads.append(json.loads(blob))
+            except json.JSONDecodeError:
+                # Some payloads are HTML attribute encoded (quotes escaped as &quot;)
+                try:
+                    payloads.append(json.loads(html_unescape(blob)))
+                except Exception:
+                    continue
+            except Exception:
+                continue
+
+    doc._json_cache = payloads
+    return payloads
+
+
+def _iter_dicts(obj: Any) -> Iterable[Dict[str, Any]]:
+    if isinstance(obj, dict):
+        yield obj
+        for value in obj.values():
+            yield from _iter_dicts(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_dicts(item)
+
+
+def _iter_strings(obj: Any) -> Iterable[str]:
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            yield from _iter_strings(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_strings(item)
+
+
+def _maybe_to_float(value: Any) -> float:
+    if isinstance(value, (int, float)):
+        try:
+            return float(value)
+        except Exception:
+            return math.nan
+    if isinstance(value, str):
+        return _to_float(value)
+    return math.nan
+
+
+def _compose_unit(row: Dict[str, Any]) -> str:
+    currency = str(row.get("currency") or row.get("currencySymbol") or "").strip()
+    unit = str(
+        row.get("unit")
+        or row.get("unitLabel")
+        or row.get("unitShort")
+        or row.get("unitName")
+        or row.get("unitSymbol")
+        or ""
+    ).strip()
+    per = str(row.get("per") or row.get("unitSuffix") or row.get("valuePer") or "").strip()
+
+    currency = currency.upper()
+    unit = unit.upper()
+    per = per.upper()
+
+    if currency and unit and "/" in unit:
+        return f"{currency}/{unit.split('/')[-1]}"
+    if currency and unit:
+        if per:
+            return f"{currency}/{unit} {per}".replace("  ", " ")
+        return f"{currency}/{unit}"
+    if currency and per:
+        return f"{currency}/{per}"
+    if currency:
+        return currency
+    return unit
+
+
+def _extract_price_rows(doc: SoupDocument) -> Tuple[List[Tuple[str, float, str]], List[Tuple[str, float, str]], List[Tuple[str, float, str]]]:
+    """Return lists of (name, value, unit) for EUR, GBP and USD price tables."""
+
+    eur_rows: List[Tuple[str, float, str]] = []
+    gbp_rows: List[Tuple[str, float, str]] = []
+    usd_rows: List[Tuple[str, float, str]] = []
+
+    for payload in _extract_json_payloads(doc):
+        for entry in _iter_dicts(payload):
+            name = entry.get("name") or entry.get("title") or entry.get("label") or entry.get("material")
+            value = entry.get("value") or entry.get("price") or entry.get("amount") or entry.get("priceValue")
+            if not name or value is None:
+                continue
+
+            unit_str = _compose_unit(entry)
+            if not unit_str:
+                # Try explicit pieces
+                currency = entry.get("currency") or entry.get("currencySymbol")
+                unit = entry.get("unit") or entry.get("unitLabel") or entry.get("unitShort")
+                per = entry.get("per") or entry.get("valuePer") or entry.get("unitSuffix")
+                unit_parts = [p for p in [currency, unit, per] if p]
+                if unit_parts:
+                    currency_part = str(unit_parts[0]).upper()
+                    rest = " ".join(str(p).upper() for p in unit_parts[1:])
+                    unit_str = currency_part if not rest else f"{currency_part}/{rest}"
+            if not unit_str:
+                continue
+
+            normalized_unit = (
+                unit_str.upper()
+                .replace("EUR /", "EUR/")
+                .replace("GBP /", "GBP/")
+                .replace("USD /", "USD/")
+                .replace("  ", " ")
+            )
+
+            price_val = _maybe_to_float(value)
+            if not math.isfinite(price_val):
+                continue
+
+            region_hint = str(entry.get("region") or entry.get("market") or entry.get("area") or "").lower()
+
+            bucket: Optional[List[Tuple[str, float, str]]] = None
+            if "GBP" in normalized_unit or "UNITED KINGDOM" in region_hint or "england" in region_hint or "uk" in region_hint:
+                bucket = gbp_rows
+            elif "EUR" in normalized_unit or "europe" in region_hint or "germany" in region_hint:
+                bucket = eur_rows
+            elif "USD" in normalized_unit:
+                bucket = usd_rows
+
+            if bucket is None:
+                # fallback on keywords in unit
+                if "GBP" in normalized_unit:
+                    bucket = gbp_rows
+                elif "EUR" in normalized_unit:
+                    bucket = eur_rows
+                elif "USD" in normalized_unit:
+                    bucket = usd_rows
+
+            if bucket is None:
+                continue
+
+            bucket.append((str(name).strip(), price_val, normalized_unit))
+
+    return eur_rows, gbp_rows, usd_rows
 
 
 # ------------------------------- normalization -------------------------------
@@ -174,82 +425,169 @@ def _usd_per_kg_from(unit_price: float, unit_str: str, fx: Dict[str, float]) -> 
 
 # --------------------------------- parsers -----------------------------------
 
-def _parse_fx(soup: BeautifulSoup) -> Dict[str, float]:
-    """
-    Extract FX from 'Currency' and 'Metal prices England' blocks to avoid cross-matching.
-    Examples on page:
-      EUR/GBP 0.87071 GBP
-      EUR/USD 1.17095 USD
-      (England) "GBP £ / USD $ 1.3422"
-    """
-    fx = {}
+def _parse_fx(doc: SoupDocument) -> Dict[str, float]:
+    """Extract FX pairs from structured payloads with text fallback."""
 
-    # Scope to 'Currency' heading if present
-    cur_heads = soup.find_all(string=re.compile(r"^\s*Currency\s*$", re.I))
-    cur_txt = ""
-    for h in cur_heads:
-        for anc in (getattr(h, "parent", None), getattr(h, "parent", None) and h.parent.parent):
-            if getattr(anc, "get_text", None):
-                t = anc.get_text(" ", strip=True)
-                # simple sanity: contains EUR/
-                if "EUR/USD" in t or "EUR / USD" in t or "EUR/GBP" in t:
-                    cur_txt = t
-                    break
-        if cur_txt:
-            break
-    if not cur_txt:
-        cur_txt = soup.get_text(" ", strip=True)
+    fx: Dict[str, float] = {}
 
-    m = re.search(r"\bEUR\s*/\s*USD\b\s*([0-9.,]+)\s*USD", cur_txt, re.I)
-    if m:
-        fx["EURUSD"] = _to_float(m.group(1))
-    m = re.search(r"\bEUR\s*/\s*GBP\b\s*([0-9.,]+)\s*GBP", cur_txt, re.I)
-    if m:
-        fx["EURGBP"] = _to_float(m.group(1))
+    # Structured JSON payloads first
+    for payload in _extract_json_payloads(doc):
+        for entry in _iter_dicts(payload):
+            pair = str(
+                entry.get("pair")
+                or entry.get("pairName")
+                or entry.get("currencyPair")
+                or entry.get("pairing")
+                or ""
+            )
+            value = entry.get("value") or entry.get("rate") or entry.get("fxRate") or entry.get("amount")
+            base = entry.get("base") or entry.get("baseCurrency") or entry.get("fromCurrency")
+            quote = entry.get("quote") or entry.get("targetCurrency") or entry.get("toCurrency")
 
-    # England area for GBP/USD number
-    eng_heads = soup.find_all(string=re.compile(r"^\s*Metal prices England\s*$", re.I))
-    eng_txt = ""
-    for h in eng_heads:
-        for anc in (getattr(h, "parent", None), getattr(h, "parent", None) and h.parent.parent):
-            if getattr(anc, "get_text", None):
-                eng_txt = anc.get_text(" ", strip=True)
-                if eng_txt:
-                    break
-        if eng_txt:
-            break
-    if not eng_txt:
-        eng_txt = soup.get_text(" ", strip=True)
+            candidates: List[Tuple[str, Any]] = []
+            if pair:
+                candidates.append((pair, value))
+            if base and quote:
+                pair_name = f"{base}/{quote}".upper()
+                candidates.append((pair_name, value or entry.get("price")))
 
-    m = re.search(r"\bGBP\b.*?/\s*\bUSD\b.*?([0-9.,]+)", eng_txt, re.I)
-    if m:
-        fx["GBPUSD"] = _to_float(m.group(1))
+            for key, raw_val in entry.items():
+                normalized_key = key.lower().replace("_", "").replace("-", "")
+                val = _maybe_to_float(raw_val)
+                if not math.isfinite(val):
+                    continue
+                if "eurusd" in normalized_key:
+                    fx.setdefault("EURUSD", val)
+                elif "eurgbp" in normalized_key:
+                    fx.setdefault("EURGBP", val)
+                elif "gbpusd" in normalized_key:
+                    fx.setdefault("GBPUSD", val)
 
-    return {k: v for k, v in fx.items() if v and math.isfinite(v)}
+            for pair_name, raw in candidates:
+                if not pair_name:
+                    continue
+                val = _maybe_to_float(raw)
+                if not math.isfinite(val):
+                    continue
+                pair_name = pair_name.upper().replace(" ", "")
+                if "EUR/USD" in pair_name or pair_name == "EURUSD":
+                    fx.setdefault("EURUSD", val)
+                elif "EUR/GBP" in pair_name or pair_name == "EURGBP":
+                    fx.setdefault("EURGBP", val)
+                elif "GBP/USD" in pair_name or pair_name == "GBPUSD":
+                    fx.setdefault("GBPUSD", val)
+
+    if len(fx) >= 3:
+        return fx
+
+    # Text fallback (old markup)
+    text = doc.get_text(" ", strip=True)
+    patterns = {
+        "EURUSD": re.compile(r"EUR\s*/\s*USD\b\s*([0-9.,\s]+)", re.I),
+        "EURGBP": re.compile(r"EUR\s*/\s*GBP\b\s*([0-9.,\s]+)", re.I),
+        "GBPUSD": re.compile(r"GBP\s*/\s*USD\b\s*([0-9.,\s]+)", re.I),
+    }
+    for key, pattern in patterns.items():
+        if key in fx and math.isfinite(fx[key]):
+            continue
+        match = pattern.search(text)
+        if match:
+            val = _to_float(match.group(1))
+            if math.isfinite(val):
+                fx[key] = val
+
+    if "GBPUSD" not in fx:
+        eurusd = fx.get("EURUSD")
+        eurgbp = fx.get("EURGBP")
+        if eurusd and eurgbp and math.isfinite(eurusd) and math.isfinite(eurgbp) and eurgbp:
+            fx["GBPUSD"] = eurusd / eurgbp
+
+    return {k: v for k, v in fx.items() if math.isfinite(v)}
 
 
-def _parse_lme_usd_per_kg(soup: BeautifulSoup, fx: Dict[str, float]) -> Tuple[Dict[str, float], Optional[str]]:
-    """
-    Scan page text for LME rows like "CU 9,862.00 USD/to" and convert to USD/kg.
-    Grab first 'Value from <date>' if present.
-    """
-    txt = soup.get_text(" ", strip=True)
+def _parse_lme_usd_per_kg(doc: SoupDocument, fx: Dict[str, float]) -> Tuple[Dict[str, float], Optional[str]]:
+    """Extract LME settlement data and an as-of date from structured payloads."""
+
     out: Dict[str, float] = {}
     asof: Optional[str] = None
 
+    for payload in _extract_json_payloads(doc):
+        for entry in _iter_dicts(payload):
+            symbol = (
+                entry.get("symbol")
+                or entry.get("code")
+                or entry.get("metal")
+                or entry.get("abbreviation")
+                or entry.get("shortName")
+                or entry.get("name")
+            )
+            unit = entry.get("unit") or entry.get("priceUnit") or entry.get("unitLabel")
+            currency = entry.get("currency") or entry.get("currencySymbol")
+            value = entry.get("value") or entry.get("price") or entry.get("amount")
+
+            unit_str = _compose_unit({"currency": currency, "unit": unit}) if (currency or unit) else str(unit or "")
+            unit_str = unit_str.replace("EUR/EUR", "EUR").replace("//", "/").strip()
+
+            if not symbol or not unit_str:
+                continue
+            symbol_str = str(symbol).strip().upper()
+            if len(symbol_str) > 3:
+                # Many structured payloads include "Copper" etc. Only keep common LME symbols.
+                if symbol_str not in {"COPPER", "NICKEL", "ZINC", "ALUMINUM", "ALUMINIUM", "TIN"}:
+                    continue
+                symbol_str = {
+                    "COPPER": "CU",
+                    "NICKEL": "NI",
+                    "ZINC": "ZN",
+                    "ALUMINUM": "AL",
+                    "ALUMINIUM": "AL",
+                    "TIN": "SN",
+                }[symbol_str]
+
+            if "USD" not in unit_str.upper():
+                continue
+
+            price = _maybe_to_float(value)
+            if not math.isfinite(price):
+                continue
+
+            try:
+                out[symbol_str] = round(_usd_per_kg_from(price, unit_str, fx), 4)
+            except Exception:
+                continue
+
+        if asof is None:
+            for text in _iter_strings(payload):
+                if not text:
+                    continue
+                match = re.search(r"(\d{4}-\d{2}-\d{2})", text)
+                if match:
+                    asof = match.group(1)
+                    break
+                match = re.search(r"([A-Za-z]{3}\s+\d{1,2},\s+\d{4})", text)
+                if match:
+                    asof = match.group(1)
+                    break
+
+    if out and asof:
+        return out, asof
+
+    # Fallback to page text heuristics
+    txt = doc.get_text(" ", strip=True)
     for sym in ("CU", "ZN", "SN", "NI", "AL"):
-        m = re.search(rf"\b{sym}\b\s*([0-9.,]+)\s*(USD\s*/\s*(?:to|t|tonne))", txt, re.I)
+        m = re.search(rf"\b{sym}\b\s*([0-9.,\s]+)\s*(USD\s*/\s*(?:TO|T|TONNE|KG))", txt, re.I)
         if m:
             price = _to_float(m.group(1))
             unit = m.group(2)
             try:
-                out[sym] = round(_usd_per_kg_from(price, unit, fx), 4)
+                out.setdefault(sym, round(_usd_per_kg_from(price, unit, fx), 4))
             except Exception:
-                pass
+                continue
 
-    d = re.search(r"Value from\s+([A-Za-z]{3}\s+\d{1,2},\s+\d{4})", txt)
-    if d:
-        asof = d.group(1)
+    if asof is None:
+        m = re.search(r"Value from\s+([A-Za-z]{3}\s+\d{1,2},\s+\d{4})", txt)
+        if m:
+            asof = m.group(1)
 
     return out, asof
 
@@ -307,46 +645,58 @@ def scrape_wieland_prices(force: bool = False, debug: bool = False) -> Dict[str,
     data["lme_usd_per_lb"] = {k: round(_usdkg_to_usdlb(v), 6) for k, v in data["lme_usd_per_kg"].items()}
     data["asof"] = asof
 
-    # EUR/100 KG rows (Metal prices) – scan whole page text
-    all_txt = soup.get_text(" ", strip=True)
-    for row in re.finditer(r"([A-Za-z0-9 \u00ae/()+\-]+?)\s+([0-9.,]+)\s+(EUR\s*/\s*100\s*KG)", all_txt, re.I):
-        name = row.group(1).strip()
-        val = _to_float(row.group(2))
-        unit = row.group(3)
-        if math.isfinite(val):
-            data["wieland_eur100kg"][name] = val
-            try:
-                data["wieland_usd_per_kg"][name] = round(_usd_per_kg_from(val, unit, fx), 4)
-                data["wieland_usd_per_lb"] = {k: round(_usdkg_to_usdlb(v), 6) for k, v in data["wieland_usd_per_kg"].items()}
-            except Exception:
-                pass
+    eur_rows, gbp_rows, usd_rows = _extract_price_rows(soup)
 
-    # England GBP/t or GBP/100 KG within England section (fallback to whole page)
-    eng_heads = soup.find_all(string=re.compile(r"^\s*Metal prices England\s*$", re.I))
-    eng_txt = ""
-    for h in eng_heads:
-        for anc in (getattr(h, "parent", None), getattr(h, "parent", None) and h.parent.parent):
-            if getattr(anc, "get_text", None):
-                eng_txt = anc.get_text(" ", strip=True)
-                if eng_txt:
-                    break
-        if eng_txt:
-            break
-    if not eng_txt:
-        eng_txt = all_txt
+    for name, val, unit in eur_rows:
+        data["wieland_eur100kg"][name] = val
+        try:
+            data["wieland_usd_per_kg"][name] = round(_usd_per_kg_from(val, unit, fx), 4)
+        except Exception:
+            continue
 
-    for row in re.finditer(r"([A-Za-z0-9 ()/\-]+?)\s+([0-9.,]+)\s+(GBP\s*/\s*(?:T|TO|100\s*KG))", eng_txt, re.I):
-        name = row.group(1).strip()
-        val = _to_float(row.group(2))
-        unit = row.group(3)
-        if math.isfinite(val):
-            data["england_gbp_t"][name] = val
-            try:
-                data["england_usd_per_kg"][name] = round(_usd_per_kg_from(val, unit, fx), 4)
-                data["england_usd_per_lb"] = {k: round(_usdkg_to_usdlb(v), 6) for k, v in data["england_usd_per_kg"].items()}
+    for name, val, unit in gbp_rows:
+        data["england_gbp_t"][name] = val
+        try:
+            data["england_usd_per_kg"][name] = round(_usd_per_kg_from(val, unit, fx), 4)
+        except Exception:
+            continue
 
-            except Exception:
-                pass
+    # Some entries may already be denominated in USD/kg (direct list prices)
+    for name, val, unit in usd_rows:
+        try:
+            data["wieland_usd_per_kg"].setdefault(name, round(_usd_per_kg_from(val, unit, fx), 4))
+        except Exception:
+            continue
+
+    # Fallback on plain-text parsing if structured payloads were empty
+    if not eur_rows:
+        all_txt = soup.get_text(" ", strip=True)
+        for row in re.finditer(r"([A-Za-z0-9 \u00ae/()+\-]+?)\s+([0-9.,]+)\s+(EUR\s*/\s*100\s*KG)", all_txt, re.I):
+            name = row.group(1).strip()
+            val = _to_float(row.group(2))
+            unit = row.group(3)
+            if math.isfinite(val):
+                data["wieland_eur100kg"][name] = val
+                try:
+                    data["wieland_usd_per_kg"][name] = round(_usd_per_kg_from(val, unit, fx), 4)
+                except Exception:
+                    continue
+
+    if not gbp_rows:
+        all_txt = soup.get_text(" ", strip=True)
+        for row in re.finditer(r"([A-Za-z0-9 ()/\-]+?)\s+([0-9.,]+)\s+(GBP\s*/\s*(?:T|TO|100\s*KG))", all_txt, re.I):
+            name = row.group(1).strip()
+            val = _to_float(row.group(2))
+            unit = row.group(3)
+            if math.isfinite(val):
+                data["england_gbp_t"][name] = val
+                try:
+                    data["england_usd_per_kg"][name] = round(_usd_per_kg_from(val, unit, fx), 4)
+                except Exception:
+                    continue
+
+    data["wieland_usd_per_lb"] = {k: round(_usdkg_to_usdlb(v), 6) for k, v in data["wieland_usd_per_kg"].items()}
+    data["england_usd_per_lb"] = {k: round(_usdkg_to_usdlb(v), 6) for k, v in data["england_usd_per_kg"].items()}
 
     # cache
     _MEM_CACHE["data"] = (now, data)

--- a/tests/pricing/test_wieland_scraper.py
+++ b/tests/pricing/test_wieland_scraper.py
@@ -1,0 +1,102 @@
+import os
+
+import pytest
+
+from cad_quoter.pricing import wieland_scraper
+
+
+SAMPLE_HTML = """
+<html>
+  <head>
+    <script id="__NEXT_DATA__" type="application/json">
+      {"props": {"pageProps": {"data": {"metalInformation": {
+        "lastUpdate": "2024-10-05",
+        "currencyRates": [
+          {"pair": "EUR/USD", "value": "1,0965"},
+          {"pair": "EUR/GBP", "value": "0,8564"},
+          {"baseCurrency": "GBP", "targetCurrency": "USD", "rate": "1.2819"}
+        ],
+        "lme": [
+          {"symbol": "CU", "value": "9,862.00", "currency": "USD", "unit": "t"},
+          {"name": "Aluminum", "value": "2.310,5", "currency": "USD", "unit": "t"}
+        ],
+        "metalPricesEurope": [
+          {"name": "Wieland Kupfer", "value": "8 120,00", "currency": "EUR", "unit": "100 kg"},
+          {"name": "MS 58I", "value": "430,20", "currency": "EUR", "unit": "100 kg"}
+        ],
+        "metalPricesEngland": [
+          {"name": "Copper Rod", "value": "8 200,0", "currency": "GBP", "unit": "t", "region": "England"},
+          {"name": "Brass", "value": "410", "currency": "GBP", "unit": "100 kg", "region": "United Kingdom"}
+        ],
+        "usdList": [
+          {"name": "Direct USD", "value": "6.50", "currency": "USD", "unit": "kg"}
+        ]
+      }}}}}
+    </script>
+  </head>
+  <body>
+    <main>Metal information snapshot</main>
+  </body>
+</html>
+"""
+
+
+def _make_doc():
+    return wieland_scraper.SoupDocument(SAMPLE_HTML)
+
+
+def test_parse_fx_from_structured_payload() -> None:
+    doc = _make_doc()
+    fx = wieland_scraper._parse_fx(doc)
+    assert pytest.approx(fx["EURUSD"], rel=1e-6) == 1.0965
+    assert pytest.approx(fx["EURGBP"], rel=1e-6) == 0.8564
+    # GBPUSD is pulled directly from payload (and falls back to cross if missing)
+    assert pytest.approx(fx["GBPUSD"], rel=1e-6) == 1.2819
+
+
+def test_scrape_wieland_prices_from_structured_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wieland_scraper, "_get_soup", lambda debug=False: _make_doc())
+    monkeypatch.setattr(wieland_scraper, "_write_temp_cache", lambda data: None)
+    monkeypatch.setattr(wieland_scraper, "_read_temp_cache", lambda: None)
+    # clear caches so we exercise the parsing path each time
+    wieland_scraper._MEM_CACHE.clear()
+    try:
+        data = wieland_scraper.scrape_wieland_prices(force=True)
+
+        assert data["fx"]["EURUSD"] == pytest.approx(1.0965)
+        assert data["fx"]["GBPUSD"] == pytest.approx(1.2819)
+        assert data["asof"] == "2024-10-05"
+
+        assert data["wieland_eur100kg"]["Wieland Kupfer"] == pytest.approx(8120.0)
+        assert data["wieland_usd_per_kg"]["Wieland Kupfer"] == pytest.approx(89.0358, rel=1e-5)
+
+        assert data["wieland_usd_per_kg"]["Direct USD"] == pytest.approx(6.5)
+
+        assert data["england_gbp_t"]["Copper Rod"] == pytest.approx(8200.0)
+        assert data["england_usd_per_kg"]["Copper Rod"] == pytest.approx(10.51158, rel=1e-5)
+
+        # LME conversions converted to USD/kg
+        assert data["lme_usd_per_kg"]["CU"] == pytest.approx(9.862)
+        assert data["lme_usd_per_kg"]["AL"] == pytest.approx(2.3105)
+
+        # USD/lb conversion sanity check
+        assert data["england_usd_per_lb"]["Copper Rod"] == pytest.approx(
+            wieland_scraper._usdkg_to_usdlb(data["england_usd_per_kg"]["Copper Rod"]), rel=1e-6
+        )
+    finally:
+        wieland_scraper._MEM_CACHE.clear()
+        cache_path = wieland_scraper._cache_path()
+        if os.path.exists(cache_path):
+            os.remove(cache_path)
+
+
+def test_to_float_handles_localized_formats() -> None:
+    cases = {
+        "8 120,00": 8120.0,
+        "2.310,5": 2310.5,
+        "9 862.00": 9862.0,
+        "1 234,56": 1234.56,
+        "6.50": 6.5,
+    }
+    for raw, expected in cases.items():
+        assert wieland_scraper._to_float(raw) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- replace the Wieland scraper HTTP and parsing stack to cope with the new Next.js JSON payloads and localized number formats
- add richer logging around Wieland lookup failures so callers surface actionable errors
- cover the new selectors and locale-aware parsing with dedicated scraper unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd4879db9883208d9bde41a89a5e5f