### PR TITLE
Move quote rationale after pricing ladder

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5152,13 +5152,6 @@ def render_quote(
     row("Total", pass_total, indent="  ")
     lines.append("")
 
-    if why_parts:
-        lines.append("Why this price")
-        lines.append(divider)
-        for part in why_parts:
-            write_wrapped(part, "  ")
-        lines.append("")
-
     # ---- Pricing ladder ------------------------------------------------------
     lines.append("Pricing Ladder")
     lines.append(divider)
@@ -5187,6 +5180,16 @@ def render_quote(
             for w in _tw.wrap(str(n), width=page_width):
                 lines.append(f"- {w}")
         lines.append("")
+
+    if why_parts:
+        if lines and lines[-1]:
+            lines.append("")
+        lines.append("Why this price")
+        lines.append(divider)
+        for part in why_parts:
+            write_wrapped(part, "  ")
+        if lines[-1]:
+            lines.append("")
 
     return "\n".join(lines)
 # ===== QUOTE CONFIG (edit-friendly) ==========================================

--- a/tests/pricing/test_render_quote_ordering.py
+++ b/tests/pricing/test_render_quote_ordering.py
@@ -1,0 +1,52 @@
+import appV5
+
+
+def test_render_quote_places_why_after_pricing_ladder_and_llm_adjustments() -> None:
+    result = {
+        "price": 54.19,
+        "narrative": "Tight tolerance adds inspection time.",
+        "llm_notes": ["LLM suggested fixture optimization."],
+        "breakdown": {
+            "qty": 3,
+            "totals": {
+                "labor_cost": 30.0,
+                "direct_costs": 10.0,
+                "subtotal": 40.0,
+                "with_overhead": 44.0,
+                "with_ga": 46.2,
+                "with_contingency": 47.124,
+                "with_expedite": 47.124,
+            },
+            "nre_detail": {},
+            "nre": {},
+            "material": {},
+            "process_costs": {"machining": 25.0},
+            "process_meta": {},
+            "pass_through": {"material": 5.0},
+            "applied_pcts": {
+                "OverheadPct": 0.10,
+                "GA_Pct": 0.05,
+                "ContingencyPct": 0.02,
+                "MarginPct": 0.15,
+            },
+            "rates": {},
+            "params": {},
+            "labor_cost_details": {},
+            "direct_cost_details": {},
+        },
+    }
+
+    rendered = appV5.render_quote(result, currency="$")
+    lines = rendered.splitlines()
+
+    assert "Pricing Ladder" in lines
+    assert "LLM Adjustments" in lines
+    assert "Why this price" in lines
+
+    pricing_idx = lines.index("Pricing Ladder")
+    llm_idx = lines.index("LLM Adjustments")
+    why_idx = lines.index("Why this price")
+
+    assert pricing_idx < llm_idx < why_idx
+    assert lines[why_idx - 1] == ""
+    assert rendered.endswith("\n")


### PR DESCRIPTION
## Summary
- move the "Why this price" section of the quote summary after the pricing ladder and optional LLM adjustments while keeping spacing tidy
- add a unit test that exercises render_quote and asserts the ordering and trailing newline behaviour

## Testing
- pytest tests/pricing/test_render_quote_ordering.py

------
https://chatgpt.com/codex/tasks/task_e_68dd639f49f883209133740afb1714ba