### PR TITLE
Move editor base text into tooltip indicator

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -13337,12 +13337,7 @@ class App(tk.Tk):
                 ttk.Entry(control_container, textvariable=var, width=30).grid(row=0, column=0, sticky="w")
                 base_text = control_spec.base_text.strip() if isinstance(control_spec.base_text, str) else ""
                 if base_text:
-                    ttk.Label(
-                        control_container,
-                        text=f"Based on: {base_text}",
-                        wraplength=260,
-                        foreground="#555555",
-                    ).grid(row=0, column=1, sticky="w", padx=(6, 0))
+                    _add_info_label(f"Based on: {base_text}")
                 self.quote_vars[item_name] = var
                 self._register_editor_field(item_name, var, label_widget)
 


### PR DESCRIPTION
## Summary
- route editor base text details through the existing tooltip indicator in the quote editor
- ensure the tooltip combines the base text with "Why it Matters" and "Typical Price Swing" notes instead of rendering an inline label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd639e7fb08320a11ea2bfe147f77a