### PR TITLE
Allow GEO overrides to seed thickness

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -13095,7 +13095,7 @@ class App(tk.Tk):
         df = _ensure_row(df, "Scrap Percent (%)", 15.0, dtype="number")
         df = _ensure_row(df, "Plate Length (in)", 12.0, dtype="number")
         df = _ensure_row(df, "Plate Width (in)", 14.0, dtype="number")
-        df = _ensure_row(df, "Thickness (in)", 0.25, dtype="number")
+        df = _ensure_row(df, "Thickness (in)", 0.0, dtype="number")
         df = _ensure_row(df, "Hole Count (override)", 0, dtype="number")
         df = _ensure_row(df, "Avg Hole Diameter (mm)", 0.0, dtype="number")
         df = _ensure_row(df, "Material", "", dtype="text")

--- a/tests/app/test_editor_helpers.py
+++ b/tests/app/test_editor_helpers.py
@@ -23,6 +23,7 @@ def _make_stub_app():
     app.editor_label_widgets = {}
     app.editor_label_base = {}
     app._editor_set_depth = 0
+    app.default_material_display = ""
     return app
 
 
@@ -86,4 +87,21 @@ def test_infer_geo_override_defaults_uses_bins_and_back_face():
     assert defaults["Avg Hole Diameter (mm)"] == pytest.approx(expected_avg)
     assert defaults["Number of Milling Setups"] == 2
     assert defaults["Scrap Percent (%)"] == pytest.approx(8.0)
+
+
+def test_apply_geo_defaults_populates_thickness(monkeypatch):
+    app = _make_stub_app()
+    thickness_var = DummyVar("0.0")
+    app.editor_vars["Thickness (in)"] = thickness_var
+
+    monkeypatch.setattr(
+        appV5,
+        "infer_geo_override_defaults",
+        lambda geo: {"Thickness (in)": 1.0},
+    )
+
+    app._apply_geo_defaults({})
+
+    assert thickness_var.get() == "1.000"
+    assert app.editor_value_sources["Thickness (in)"] == "GEO"
 


### PR DESCRIPTION
## Summary
- set the editor's default thickness value to a neutral zero so GEO-provided thickness values are not ignored
- extend the editor helper tests with a regression that verifies GEO defaults can populate the thickness field

## Testing
- pytest tests/app/test_editor_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dd80eb99bc83208438276c2120ee48