### PR TITLE
Improve material density selection for plate workflow

### DIFF
--- a/tests/test_material_density.py
+++ b/tests/test_material_density.py
@@ -1,0 +1,18 @@
+import math
+
+from appV5 import _density_for_material, _material_family, net_mass_kg
+
+
+def test_net_mass_kg_uses_copper_density():
+    density = _density_for_material("Copper")
+    assert math.isclose(density, 8.96, rel_tol=0.02)
+
+    length_in = 4.0
+    width_in = 3.0
+    thickness_in = 0.5
+    expected_mass = (length_in * width_in * thickness_in * 16.387064 * density) / 1000.0
+
+    mass = net_mass_kg(length_in, width_in, thickness_in, [], density)
+    assert math.isclose(mass, expected_mass, rel_tol=1e-9)
+
+    assert _material_family("Copper") == "copper"


### PR DESCRIPTION
## Summary
- expand material family detection to include titanium, copper, brass, and plastics
- prefer contextual or detailed density hints before falling back to coarse lookups for 2D plate densities
- add a regression test ensuring copper plate masses use the ~8.9 g/cc density

## Testing
- pytest tests/test_material_density.py

------
https://chatgpt.com/codex/tasks/task_e_68dd80ed0844832095233fd1e1f8a98a