### PR TITLE
Refactor runtime helpers and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,67 @@
 # CAD Quoting Tool
 
+The CAD Quoting Tool is a desktop workflow for estimating part pricing from
+engineering data.  It loads customer CAD (STEP/IGES/STL/DXF), applies quoting
+heuristics, and optionally calls a local Qwen vision model to propose override
+values for the standard quoting variables.  The Tkinter UI also exposes
+override, audit and debugging panels so estimators can review generated quotes
+before export.
+
+## Prerequisites
+
+* Python 3.11 or newer
+* Windows, macOS or Linux with OpenCascade libraries available (for STEP/IGES)
+* Optional: locally downloaded Qwen2.5-VL GGUF weights for LLM-assisted quoting
+
+> **Tip:** The runtime checks for a few third-party Python packages at startup
+> (`requests`, `beautifulsoup4` and `lxml`).  Install them with the provided
+> `requirements.txt` before launching the UI.
+
 ## Setup
 
-1. Install Python 3.11 or newer on the target machine.
-2. Create and activate a virtual environment:
+1. Create and activate a virtual environment in the repository root:
    ```bash
    python -m venv .venv
-   source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
    ```
-3. Install the runtime dependencies:
+2. Install the runtime dependencies:
    ```bash
    pip install -r requirements.txt
    ```
+3. (Optional) Place Qwen GGUF weights in one of the recognised locations:
+   * Set `QWEN_GGUF_PATH` and, for vision models, `QWEN_VL_MMPROJ_PATH`.
+   * Or copy the `.gguf` files into `models/` next to `appV5.py`.
+   * Legacy installs under `D:\CAD_Quoting_Tool\models` continue to be
+     auto-discovered.
 
 ## Running the application
 
-After installing the dependencies, run the main application entry point:
+Launch the Tkinter UI after activating the virtual environment:
 
 ```bash
 python appV5.py
 ```
 
-You can quickly verify the environment configuration without launching the UI:
+Useful command-line flags:
+
+* `--print-env` – dump a JSON report of the active configuration and exit.
+* `--no-gui` – initialise dependencies without opening the Tkinter window.
+
+## Tests and linting
+
+Automated checks live under `tests/`.  Run the suite with:
 
 ```bash
-python appV5.py --print-env
+pytest
 ```
 
-Refer to the [deployment guide](docs/deployment_guide.md) for end-to-end packaging and
-host preparation steps when moving the tool to another device.
+The repository also includes a `docs/` directory with deployment notes and
+integration guides for downstream teams.
+
+## Troubleshooting
+
+* Missing packages: ensure `pip install -r requirements.txt` has been executed.
+* Missing LLM weights: set the `QWEN_*` environment variables or drop the
+  required `.gguf` files into a `models/` directory.
+* DXF enrichment: install `ezdxf` and (optionally) ODA File Converter to enable
+  the DXF parsing shortcuts used by the geometry helpers.

--- a/appV5.py
+++ b/appV5.py
@@ -15,13 +15,14 @@ Single-file CAD Quoter (v8)
 from __future__ import annotations
 
 import argparse
-import json, math, os, time, gc
+import json, math, os, time
 from collections import Counter
 from fractions import Fraction
 from pathlib import Path
 from dataclasses import dataclass, field
 
 from cad_quoter.app.container import ServiceContainer, create_default_container
+from cad_quoter.app import runtime as _runtime
 from cad_quoter.config import (
     AppEnvironment,
     ConfigError,
@@ -49,32 +50,50 @@ import textwrap
 import tkinter as tk
 import tkinter.font as tkfont
 import urllib.request
-import importlib.util
-from importlib import import_module
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import cad_quoter.geometry as geometry
 
 
-_REQUIRED_RUNTIME_PACKAGES = {
-    "requests": "requests",
-    "bs4": "beautifulsoup4",
-    "lxml": "lxml",
-}
+ensure_runtime_dependencies = _runtime.ensure_runtime_dependencies
+find_default_qwen_model = _runtime.find_default_qwen_model
+load_qwen_vl = _runtime.load_qwen_vl
 
-_missing_runtime_packages = [
-    (module, dist_name)
-    for module, dist_name in _REQUIRED_RUNTIME_PACKAGES.items()
-    if importlib.util.find_spec(module) is None
-]
+ensure_runtime_dependencies()
 
-if _missing_runtime_packages:
-    missing_dists = ", ".join(dist_name for _, dist_name in _missing_runtime_packages)
-    raise ImportError(
-        "Required runtime dependencies are missing. Install them with "
-        "`pip install -r requirements.txt` before launching appV5.py "
-        f"(missing: {missing_dists})."
-    )
+# Backwards compatibility: legacy module-level names expected by tests/scripts
+_DEFAULT_VL_MODEL_NAMES = _runtime.DEFAULT_VL_MODEL_NAMES
+_DEFAULT_MM_PROJ_NAMES = _runtime.DEFAULT_MM_PROJ_NAMES
+VL_MODEL = str(_runtime.LEGACY_VL_MODEL)
+MM_PROJ = str(_runtime.LEGACY_MM_PROJ)
+LEGACY_VL_MODEL = str(_runtime.LEGACY_VL_MODEL)
+LEGACY_MM_PROJ = str(_runtime.LEGACY_MM_PROJ)
+PREFERRED_MODEL_DIRS: list[str | Path] = [str(p) for p in _runtime.PREFERRED_MODEL_DIRS]
+
+
+def discover_qwen_vl_assets(
+    *,
+    model_path: str | None = None,
+    mmproj_path: str | None = None,
+) -> tuple[str, str]:
+    """Wrapper that honours ``appV5.PREFERRED_MODEL_DIRS`` overrides."""
+
+    previous_dirs = _runtime.PREFERRED_MODEL_DIRS
+    try:
+        override_dirs: list[Path] = []
+        for value in PREFERRED_MODEL_DIRS:
+            try:
+                override_dirs.append(Path(value).expanduser())
+            except Exception:
+                continue
+        if override_dirs:
+            _runtime.PREFERRED_MODEL_DIRS = tuple(override_dirs)
+        return _runtime.discover_qwen_vl_assets(
+            model_path=model_path,
+            mmproj_path=mmproj_path,
+        )
+    finally:
+        _runtime.PREFERRED_MODEL_DIRS = previous_dirs
 
 from cad_quoter.domain_models import (
     DEFAULT_MATERIAL_DISPLAY,
@@ -134,8 +153,6 @@ from OCP.BRepAdaptor import BRepAdaptor_Surface as _BAS
 
 import pandas as pd
 
-from llama_cpp import Llama  # type: ignore
-
 try:
     from geo_read_more import build_geo_from_dxf as build_geo_from_dxf_path
 except Exception:
@@ -159,16 +176,6 @@ def build_geo_from_dxf(path: str) -> dict:
     if not loader:
         raise RuntimeError("DXF enrichment helper is unavailable")
     return loader(path)
-
-def _match_items_contains(items: pd.Series, pattern: str) -> pd.Series:
-    """Case-insensitive regex match over Items."""
-
-    pat = _to_noncapturing(pattern) if "_to_noncapturing" in globals() else pattern
-    try:
-        return items.str.contains(pat, case=False, regex=True, na=False)
-    except Exception:
-        return items.str.contains(re.escape(pattern), case=False, regex=True, na=False)
-
 
 # Geometry helpers (re-exported for backward compatibility)
 load_model = geometry.load_model
@@ -194,12 +201,6 @@ _HAS_TRIMESH = geometry.HAS_TRIMESH
 _HAS_EZDXF = geometry.HAS_EZDXF
 _HAS_ODAFC = geometry.HAS_ODAFC
 _EZDXF_VER = geometry.EZDXF_VERSION
-
-
-def _normalize_lookup_key(value: str) -> str:
-    cleaned = re.sub(r"[^0-9a-z]+", " ", str(value).strip().lower())
-    return re.sub(r"\s+", " ", cleaned).strip()
-
 
 def _ensure_scrap_pct(val) -> float:
     """
@@ -230,207 +231,6 @@ def _match_items_contains(items: pd.Series, pattern: str) -> pd.Series:
         return items.str.contains(pat, case=False, regex=True, na=False)
     except Exception:
         return items.str.contains(re.escape(pattern), case=False, regex=True, na=False)
-
-VL_MODEL = r"D:\CAD_Quoting_Tool\models\qwen2.5-vl-7b-instruct-q4_k_m.gguf"
-MM_PROJ = r"D:\CAD_Quoting_Tool\models\mmproj-Qwen2.5-VL-3B-Instruct-Q8_0.gguf"
-
-_LEGACY_VL_MODEL = Path(VL_MODEL)
-_LEGACY_MM_PROJ = Path(MM_PROJ)
-
-_DEFAULT_VL_MODEL_NAMES = (
-    _LEGACY_VL_MODEL.name,
-    "qwen2.5-vl-7b-instruct-q4_0.gguf",
-    "qwen2.5-vl-7b-instruct-q4_k_s.gguf",
-    "qwen2-vl-7b-instruct-q4_0.gguf",
-)
-
-_DEFAULT_MM_PROJ_NAMES = (
-    _LEGACY_MM_PROJ.name,
-    "mmproj-Qwen2.5-VL-3B-Instruct-Q4_0.gguf",
-    "mmproj-Qwen2-VL-7B-Instruct-Q4_0.gguf",
-)
-
-
-def _dedupe_paths(paths: Iterable[Path]) -> list[Path]:
-    seen: set[str] = set()
-    unique: list[Path] = []
-    for raw in paths:
-        try:
-            candidate = raw.expanduser()
-        except Exception:
-            continue
-        key = str(candidate.resolve() if candidate.exists() else candidate)
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append(candidate)
-    return unique
-
-
-def _collect_model_dirs(*paths: str | Path | None) -> list[Path]:
-    dirs: list[Path] = []
-    for value in paths:
-        if not value:
-            continue
-        try:
-            candidate = Path(value).expanduser()
-        except Exception:
-            continue
-        if candidate.is_file():
-            dirs.append(candidate.parent)
-        elif candidate.is_dir():
-            dirs.append(candidate)
-        else:
-            dirs.append(candidate.parent)
-    for env_var in ("QWEN_MODELS_DIR", "QWEN_VL_MODELS_DIR"):
-        env_value = os.environ.get(env_var)
-        if env_value:
-            try:
-                dirs.append(Path(env_value).expanduser())
-            except Exception:
-                continue
-    dirs.extend(Path(d) for d in PREFERRED_MODEL_DIRS)
-    try:
-        dirs.append(Path(__file__).resolve().parent / "models")
-    except Exception:
-        pass
-    dirs.append(Path.cwd() / "models")
-    return [d for d in _dedupe_paths(dirs) if str(d)]
-
-
-def _find_weight_file(
-    names: Sequence[str],
-    directories: Sequence[Path],
-    glob: str,
-) -> str:
-    for directory in directories:
-        try:
-            if not directory.exists():
-                continue
-        except Exception:
-            continue
-        for name in names:
-            candidate = directory / name
-            if candidate.is_file():
-                return str(candidate)
-        try:
-            matches = list(directory.glob(glob))
-        except Exception:
-            matches = []
-        if matches:
-            try:
-                matches.sort(key=lambda p: (-p.stat().st_size, p.name))
-            except Exception:
-                matches.sort()
-            return str(matches[0])
-    return ""
-
-
-def discover_qwen_vl_assets(
-    *,
-    model_path: str | None = None,
-    mmproj_path: str | None = None,
-) -> tuple[str, str]:
-    """Locate Qwen vision model + projector weights on disk.
-
-    The desktop application historically shipped with hard-coded Windows
-    paths.  Modern deployments may store the weights alongside the script or
-    expose them via environment variables.  This helper consolidates the
-    discovery logic and returns fully-qualified filesystem paths.  A
-    ``RuntimeError`` is raised with actionable guidance when the assets cannot
-    be resolved.
-    """
-
-    model_candidates = [
-        model_path,
-        os.environ.get("QWEN_VL_GGUF_PATH"),
-        os.environ.get("QWEN_GGUF_PATH"),
-        str(_LEGACY_VL_MODEL),
-    ]
-    mmproj_candidates = [
-        mmproj_path,
-        os.environ.get("QWEN_VL_MMPROJ_PATH"),
-        os.environ.get("QWEN_MMPROJ_PATH"),
-        str(_LEGACY_MM_PROJ),
-    ]
-
-    def _first_existing(paths: Sequence[str | None]) -> str:
-        for value in paths:
-            if not value:
-                continue
-            try:
-                candidate = Path(value).expanduser()
-            except Exception:
-                continue
-            if candidate.is_file():
-                return str(candidate)
-        return ""
-
-    model_file = _first_existing(model_candidates)
-    mmproj_file = _first_existing(mmproj_candidates)
-
-    search_dirs = _collect_model_dirs(*(model_candidates + mmproj_candidates))
-
-    if not model_file:
-        model_file = _find_weight_file(_DEFAULT_VL_MODEL_NAMES, search_dirs, "*vl*.gguf")
-    if not mmproj_file:
-        mmproj_file = _find_weight_file(_DEFAULT_MM_PROJ_NAMES, search_dirs, "*mmproj*.gguf")
-
-    if not model_file or not mmproj_file:
-        searched = ", ".join(str(d) for d in search_dirs if d)
-        raise RuntimeError(
-            "Vision LLM weights not found. Set QWEN_VL_GGUF_PATH and "
-            "QWEN_VL_MMPROJ_PATH (or place matching *.gguf files in one of: "
-            f"{searched or 'the known model directories'})."
-        )
-
-    return model_file, mmproj_file
-
-
-def load_qwen_vl(
-    n_ctx: int = 8192,
-    n_gpu_layers: int = 20,
-    n_threads: int | None = None,
-    *,
-    model_path: str | None = None,
-    mmproj_path: str | None = None,
-):
-    """Load Qwen2.5-VL with vision projector configured for llama.cpp."""
-
-    if n_threads is None:
-        cpu_count = os.cpu_count() or 8
-        n_threads = max(4, cpu_count // 2)
-
-    model_file, mmproj_file = discover_qwen_vl_assets(
-        model_path=model_path,
-        mmproj_path=mmproj_path,
-    )
-
-    try:
-        llm = Llama(
-            model_path=model_file,
-            mmproj_path=mmproj_file,
-            n_ctx=n_ctx,
-            n_gpu_layers=n_gpu_layers,
-            n_threads=n_threads,
-            chat_format="qwen2_vl",
-            verbose=False,
-        )
-        _ = llm.create_chat_completion(
-            messages=[
-                {"role": "system", "content": "Return JSON {\"ok\":true}."},
-                {"role": "user", "content": "ping"},
-            ],
-            max_tokens=16,
-            temperature=0,
-        )
-        return llm
-    except Exception:
-        if n_ctx > 4096:
-            gc.collect()
-            return load_qwen_vl(n_ctx=4096, n_gpu_layers=0, n_threads=n_threads)
-        raise
-
 
 def _auto_accept_suggestions(suggestions: dict[str, Any] | None) -> dict[str, Any]:
     accept: dict[str, Any] = {}
@@ -2924,80 +2724,6 @@ from tkinter import ttk, filedialog, messagebox
 import subprocess, tempfile, shutil
 
 
-# --------------------- helpers: model discovery ---------------------
-PREFERRED_MODEL_DIRS = [
-    r"D:\CAD_Quoting_Tool\models",
-]
-
-def _pick_best_gguf(paths):
-    # Prefer files with 'qwen' and 'instruct'; otherwise choose the largest.
-    if not paths:
-        return ""
-    paths = [Path(p) for p in paths if Path(p).is_file() and p.lower().endswith(".gguf")]
-    if not paths:
-        return ""
-    preferred = [p for p in paths if ("qwen" in p.name.lower() and "instr" in p.name.lower())]
-    pool = preferred or paths
-    # Largest by size
-    try:
-        best = max(pool, key=lambda p: p.stat().st_size)
-    except Exception:
-        best = pool[0]
-    return str(best)
-
-def find_default_qwen_model():
-    # 1) Env
-    envp = os.environ.get("QWEN_GGUF_PATH", "")
-    if envp and Path(envp).is_file():
-        return envp
-    # 2) D:\CAD_Quoting_Tool\models
-    for d in PREFERRED_MODEL_DIRS:
-        dpath = Path(d)
-        if dpath.is_dir():
-            ggufs = list(dpath.glob("*.gguf"))
-            choice = _pick_best_gguf([str(p) for p in ggufs])
-            if choice: return choice
-    # 3) script_dir\models
-    try:
-        sdir = Path(__file__).resolve().parent
-        ggufs = list((sdir / "models").glob("*.gguf"))
-        choice = _pick_best_gguf([str(p) for p in ggufs])
-        if choice: return choice
-    except Exception:
-        pass
-    # 4) cwd\models
-    ggufs = list((Path.cwd() / "models").glob("*.gguf"))
-    choice = _pick_best_gguf([str(p) for p in ggufs])
-    if choice: return choice
-    return ""
-
-# Optional trimesh for STL
-try:
-    import trimesh  # type: ignore
-    _HAS_TRIMESH = True
-except Exception:
-    _HAS_TRIMESH = False
-
-_HAS_EZDXF  = False
-_HAS_ODAFC  = False      # ezdxf.addons.odafc (uses ODA File Converter)
-_EZDXF_VER  = "unknown"
-
-try:
-    import ezdxf
-    _EZDXF_VER = getattr(ezdxf, "__version__", "unknown")
-    _HAS_EZDXF = True
-except Exception:
-    ezdxf = None  # keep name defined
-
-# odafc is optional; don't fail if it's not present
-try:
-    if _HAS_EZDXF:
-        from ezdxf.addons import odafc  # type: ignore
-        _HAS_ODAFC = True
-except Exception:
-    _HAS_ODAFC = False
-
-# Hole chart helpers (optional)
 try:
     from hole_table_parser import parse_hole_table_lines
 except Exception:
@@ -4220,7 +3946,10 @@ def enrich_geo_stl(path):
         raise RuntimeError("trimesh not available to process STL")
     
     logger.info("[%.2fs] Loading mesh...", time.time() - start_time)
-    mesh = trimesh.load(path, force='mesh')
+    trimesh_mod = getattr(geometry, "trimesh", None)
+    if trimesh_mod is None:
+        raise RuntimeError("trimesh is unavailable despite HAS_TRIMESH flag")
+    mesh = trimesh_mod.load(path, force="mesh")
     logger.info(
         "[%.2fs] Mesh loaded. Faces: %d",
         time.time() - start_time,

--- a/cad_quoter/app/__init__.py
+++ b/cad_quoter/app/__init__.py
@@ -1,8 +1,11 @@
 """Application-level helpers for the CAD quoting tool."""
+from __future__ import annotations
 
 from .container import ServiceContainer, create_default_container
+from . import runtime
 
 __all__ = [
     "ServiceContainer",
     "create_default_container",
+    "runtime",
 ]

--- a/cad_quoter/app/runtime.py
+++ b/cad_quoter/app/runtime.py
@@ -1,0 +1,303 @@
+"""Runtime helpers shared by the desktop UI entrypoint."""
+from __future__ import annotations
+
+import gc
+import importlib.util
+import os
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from llama_cpp import Llama  # type: ignore
+
+# Runtime dependencies required when the desktop UI launches.  These are kept
+# here so they can be reused in tests without importing the enormous Tk UI
+# module.
+REQUIRED_RUNTIME_PACKAGES: dict[str, str] = {
+    "requests": "requests",
+    "bs4": "beautifulsoup4",
+    "lxml": "lxml",
+}
+
+# Historical Windows installs placed the GGUF files in this directory.  We keep
+# it in the search path so the upgraded runtime can still discover the models
+# automatically for those environments.
+PREFERRED_MODEL_DIRS: tuple[Path, ...] = (
+    Path(r"D:\CAD_Quoting_Tool\models"),
+)
+
+# Legacy filenames from earlier builds.  The discovery helpers will fall back to
+# these names if no explicit paths are provided.
+LEGACY_VL_MODEL = Path(r"D:\CAD_Quoting_Tool\models\qwen2.5-vl-7b-instruct-q4_k_m.gguf")
+LEGACY_MM_PROJ = Path(r"D:\CAD_Quoting_Tool\models\mmproj-Qwen2.5-VL-3B-Instruct-Q8_0.gguf")
+
+DEFAULT_VL_MODEL_NAMES = (
+    LEGACY_VL_MODEL.name,
+    "qwen2.5-vl-7b-instruct-q4_0.gguf",
+    "qwen2.5-vl-7b-instruct-q4_k_s.gguf",
+    "qwen2-vl-7b-instruct-q4_0.gguf",
+)
+
+DEFAULT_MM_PROJ_NAMES = (
+    LEGACY_MM_PROJ.name,
+    "mmproj-Qwen2.5-VL-3B-Instruct-Q4_0.gguf",
+    "mmproj-Qwen2-VL-7B-Instruct-Q4_0.gguf",
+)
+
+
+def ensure_runtime_dependencies() -> None:
+    """Raise :class:`ImportError` if optional-but-required packages are missing."""
+
+    missing = [
+        (module, dist_name)
+        for module, dist_name in REQUIRED_RUNTIME_PACKAGES.items()
+        if importlib.util.find_spec(module) is None
+    ]
+    if not missing:
+        return
+
+    missing_dists = ", ".join(dist_name for _, dist_name in missing)
+    raise ImportError(
+        "Required runtime dependencies are missing. Install them with "
+        "`pip install -r requirements.txt` before launching appV5.py "
+        f"(missing: {missing_dists})."
+    )
+
+
+def _dedupe_paths(paths: Iterable[Path]) -> list[Path]:
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for raw in paths:
+        try:
+            candidate = raw.expanduser()
+        except Exception:
+            continue
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            resolved = candidate
+        key = str(resolved)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(resolved)
+    return unique
+
+
+def _collect_model_dirs(*paths: str | Path | None) -> list[Path]:
+    dirs: list[Path] = []
+    for value in paths:
+        if not value:
+            continue
+        try:
+            candidate = Path(value).expanduser()
+        except Exception:
+            continue
+        if candidate.is_file():
+            dirs.append(candidate.parent)
+        elif candidate.is_dir():
+            dirs.append(candidate)
+        else:
+            dirs.append(candidate.parent)
+    for env_var in ("QWEN_MODELS_DIR", "QWEN_VL_MODELS_DIR"):
+        env_value = os.environ.get(env_var)
+        if env_value:
+            try:
+                dirs.append(Path(env_value).expanduser())
+            except Exception:
+                continue
+    dirs.extend(PREFERRED_MODEL_DIRS)
+    try:
+        dirs.append(Path(__file__).resolve().parent / "models")
+    except Exception:
+        pass
+    dirs.append(Path.cwd() / "models")
+    return [d for d in _dedupe_paths(dirs) if str(d)]
+
+
+def _find_weight_file(
+    names: Sequence[str],
+    directories: Sequence[Path],
+    glob: str,
+) -> str:
+    for directory in directories:
+        try:
+            if not directory.exists():
+                continue
+        except Exception:
+            continue
+        for name in names:
+            candidate = directory / name
+            if candidate.is_file():
+                return str(candidate)
+        try:
+            matches = list(directory.glob(glob))
+        except Exception:
+            matches = []
+        if matches:
+            try:
+                matches.sort(key=lambda p: (-p.stat().st_size, p.name))
+            except Exception:
+                matches.sort()
+            return str(matches[0])
+    return ""
+
+
+def discover_qwen_vl_assets(
+    *,
+    model_path: str | None = None,
+    mmproj_path: str | None = None,
+) -> tuple[str, str]:
+    """Locate Qwen vision model + projector weights on disk."""
+
+    model_candidates = [
+        model_path,
+        os.environ.get("QWEN_VL_GGUF_PATH"),
+        os.environ.get("QWEN_GGUF_PATH"),
+        str(LEGACY_VL_MODEL),
+    ]
+    mmproj_candidates = [
+        mmproj_path,
+        os.environ.get("QWEN_VL_MMPROJ_PATH"),
+        os.environ.get("QWEN_MMPROJ_PATH"),
+        str(LEGACY_MM_PROJ),
+    ]
+
+    def _first_existing(paths: Sequence[str | None]) -> str:
+        for value in paths:
+            if not value:
+                continue
+            try:
+                candidate = Path(value).expanduser()
+            except Exception:
+                continue
+            if candidate.is_file():
+                return str(candidate)
+        return ""
+
+    model_file = _first_existing(model_candidates)
+    mmproj_file = _first_existing(mmproj_candidates)
+
+    search_dirs = _collect_model_dirs(*(model_candidates + mmproj_candidates))
+
+    if not model_file:
+        model_file = _find_weight_file(DEFAULT_VL_MODEL_NAMES, search_dirs, "*vl*.gguf")
+    if not mmproj_file:
+        mmproj_file = _find_weight_file(DEFAULT_MM_PROJ_NAMES, search_dirs, "*mmproj*.gguf")
+
+    if not model_file or not mmproj_file:
+        searched = ", ".join(str(d) for d in search_dirs if d)
+        raise RuntimeError(
+            "Vision LLM weights not found. Set QWEN_VL_GGUF_PATH and "
+            "QWEN_VL_MMPROJ_PATH (or place matching *.gguf files in one of: "
+            f"{searched or 'the known model directories'})."
+        )
+
+    return model_file, mmproj_file
+
+
+def load_qwen_vl(
+    n_ctx: int = 8192,
+    n_gpu_layers: int = 20,
+    n_threads: int | None = None,
+    *,
+    model_path: str | None = None,
+    mmproj_path: str | None = None,
+):
+    """Load Qwen2.5-VL with vision projector configured for llama.cpp."""
+
+    if n_threads is None:
+        cpu_count = os.cpu_count() or 8
+        n_threads = max(4, cpu_count // 2)
+
+    model_file, mmproj_file = discover_qwen_vl_assets(
+        model_path=model_path,
+        mmproj_path=mmproj_path,
+    )
+
+    try:
+        llm = Llama(
+            model_path=model_file,
+            mmproj_path=mmproj_file,
+            n_ctx=n_ctx,
+            n_gpu_layers=n_gpu_layers,
+            n_threads=n_threads,
+            chat_format="qwen2_vl",
+            verbose=False,
+        )
+        _ = llm.create_chat_completion(
+            messages=[
+                {"role": "system", "content": "Return JSON {\"ok\":true}."},
+                {"role": "user", "content": "ping"},
+            ],
+            max_tokens=16,
+            temperature=0,
+        )
+        return llm
+    except Exception:
+        if n_ctx > 4096:
+            gc.collect()
+            return load_qwen_vl(n_ctx=4096, n_gpu_layers=0, n_threads=n_threads)
+        raise
+
+
+def _pick_best_gguf(paths: Iterable[str]) -> str:
+    candidates = [Path(p) for p in paths]
+    filtered = [p for p in candidates if p.is_file() and p.suffix.lower() == ".gguf"]
+    if not filtered:
+        return ""
+    preferred = [
+        p
+        for p in filtered
+        if "qwen" in p.name.lower() and "instr" in p.name.lower()
+    ]
+    pool = preferred or filtered
+    try:
+        best = max(pool, key=lambda p: p.stat().st_size)
+    except Exception:
+        best = pool[0]
+    return str(best)
+
+
+def find_default_qwen_model() -> str:
+    """Best-effort discovery for the primary GGUF model path."""
+
+    envp = os.environ.get("QWEN_GGUF_PATH", "")
+    if envp:
+        candidate = Path(envp).expanduser()
+        if candidate.is_file():
+            return str(candidate)
+
+    for directory in PREFERRED_MODEL_DIRS:
+        if not directory.is_dir():
+            continue
+        choice = _pick_best_gguf(str(p) for p in directory.glob("*.gguf"))
+        if choice:
+            return choice
+
+    try:
+        script_dir = Path(__file__).resolve().parent
+        choice = _pick_best_gguf(str(p) for p in (script_dir / "models").glob("*.gguf"))
+        if choice:
+            return choice
+    except Exception:
+        pass
+
+    cwd_choice = _pick_best_gguf(str(p) for p in (Path.cwd() / "models").glob("*.gguf"))
+    if cwd_choice:
+        return cwd_choice
+
+    return ""
+
+
+__all__ = [
+    "DEFAULT_MM_PROJ_NAMES",
+    "DEFAULT_VL_MODEL_NAMES",
+    "LEGACY_MM_PROJ",
+    "LEGACY_VL_MODEL",
+    "PREFERRED_MODEL_DIRS",
+    "REQUIRED_RUNTIME_PACKAGES",
+    "discover_qwen_vl_assets",
+    "ensure_runtime_dependencies",
+    "find_default_qwen_model",
+    "load_qwen_vl",
+]


### PR DESCRIPTION
## Summary
- extract runtime and model discovery helpers into cad_quoter/app/runtime.py and expose them through appV5 for compatibility
- remove duplicate logic from appV5, tighten STL enrichment imports, and keep legacy attributes working
- expand the README with setup, LLM weight guidance, and troubleshooting notes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd824b6a3483209f53b9cd7d74623f