### PR TITLE
Update checkbox metadata in default template

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -8483,7 +8483,38 @@ def default_variables_template() -> pd.DataFrame:
     if _HAS_PANDAS:
         core_df, _ = _load_master_variables()
         if core_df is not None:
-            return core_df
+            updated = core_df.copy()
+            columns = list(updated.columns)
+            for required in REQUIRED_COLS:
+                if required not in columns:
+                    columns.append(required)
+            normalized_targets = {
+                "fair required": "FAIR Required",
+                "source inspection requirement": "Source Inspection Requirement",
+            }
+            seen_items: set[str] = set()
+            adjusted_rows: list[dict[str, Any]] = []
+            for _, row in updated.iterrows():
+                row_dict = dict(row)
+                item_text = str(row_dict.get("Item", "") or "")
+                normalized = item_text.strip().lower()
+                seen_items.add(normalized)
+                if normalized in normalized_targets:
+                    row_dict["Data Type / Input Method"] = "Checkbox"
+                    row_dict["Example Values / Options"] = "False / True"
+                adjusted_rows.append(row_dict)
+            for normalized, display in normalized_targets.items():
+                if normalized not in seen_items:
+                    new_row = {col: "" for col in columns}
+                    new_row.update(
+                        {
+                            "Item": display,
+                            "Data Type / Input Method": "Checkbox",
+                            "Example Values / Options": "False / True",
+                        }
+                    )
+                    adjusted_rows.append(new_row)
+            return pd.DataFrame(adjusted_rows, columns=columns)
     rows = [
         ("Overhead %", 0.15, "number"),
         ("G&A %", 0.08, "number"),
@@ -8516,8 +8547,8 @@ def default_variables_template() -> pd.DataFrame:
         ("Packaging Labor Hours", 0.0, "number"),
         ("Number of Milling Setups", 1, "number"),
         ("Setup Hours / Setup", 0.3, "number"),
-        ("FAIR Required", 0, "number"),
-        ("Source Inspection Requirement", 0, "number"),
+        ("FAIR Required", "False / True", "Checkbox"),
+        ("Source Inspection Requirement", "False / True", "Checkbox"),
         ("Quantity", 1, "number"),
         ("Material", "", "text"),
         ("Thickness (in)", 0.0, "number"),

--- a/tests/test_editor_controls.py
+++ b/tests/test_editor_controls.py
@@ -1,6 +1,6 @@
 """Unit tests for editor control classification helpers."""
 
-from appV5 import derive_editor_control_spec
+from appV5 import default_variables_template, derive_editor_control_spec
 
 
 def test_number_control_from_declared_dtype():
@@ -44,3 +44,15 @@ def test_options_without_dtype_are_promoted_to_dropdown():
     assert spec.control == "dropdown"
     assert spec.guessed_dropdown
     assert spec.options == ("Low", "Medium", "High")
+
+
+def test_default_template_flags_render_as_checkboxes():
+    df = default_variables_template()
+    for item in ("FAIR Required", "Source Inspection Requirement"):
+        row = next((row for _, row in df.iterrows() if row["Item"] == item), None)
+        assert row is not None, f"Missing {item} in default template"
+        dtype = row["Data Type / Input Method"]
+        example = row["Example Values / Options"]
+        spec = derive_editor_control_spec(dtype, example)
+        assert spec.control == "checkbox"
+        assert spec.checkbox_state is False


### PR DESCRIPTION
## Summary
- ensure the default variables template marks FAIR/source inspection flags as checkbox controls when loading the master sheet or the fallback rows
- keep the fallback template rows for those flags in sync with checkbox metadata
- add a regression test so template-driven editor helpers assert those items render as checkboxes

## Testing
- pytest tests/test_editor_controls.py
- pytest tests/app/test_editor_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dd80ee24b08320829315aefe0f1185