### PR TITLE
Fix FAIR checkbox parsing and add regression test

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -6713,9 +6713,7 @@ def compute_quote_from_df(df: pd.DataFrame,
     fai_flag_base = False
     if isinstance(ui_vars, dict):
         raw_fai = ui_vars.get("FAIR Required")
-        cand = _coerce_float_or_none(raw_fai)
-        if cand is not None:
-            fai_flag_base = bool(int(round(float(cand))))
+        fai_flag_base = _coerce_checkbox_state(raw_fai, False)
 
     baseline_data = {
         "process_hours": process_hours_baseline,
@@ -6844,11 +6842,7 @@ def compute_quote_from_df(df: pd.DataFrame,
         "in_process_inspection_hr": float(inproc_hr or 0.0),
         "packaging_hours": float(packaging_hr or 0.0),
         "packaging_flat_cost": float((crate_nre_cost or 0.0) + (packaging_mat or 0.0)),
-        "fai_required": bool(
-            int(round(float(_coerce_float_or_none(ui_vars.get("FAIR Required")) or 0.0)))
-            if isinstance(ui_vars, dict)
-            else False
-        ),
+        "fai_required": bool(fai_flag_base),
     }
     # Safely include tap/cbore counts even if later sections define seeds
     try:

--- a/tests/app/test_fai_checkbox.py
+++ b/tests/app/test_fai_checkbox.py
@@ -1,0 +1,37 @@
+"""Regression tests for FAIR checkbox parsing."""
+
+import appV5
+import pytest
+
+
+pd = pytest.importorskip("pandas")
+
+
+def test_fai_checkbox_true_sets_baseline_and_features(monkeypatch):
+    captured: dict[str, dict] = {}
+
+    def _capture_payload(geo, baseline, rates, bounds):
+        captured["geo"] = geo
+        return {}
+
+    monkeypatch.setattr(appV5, "build_suggest_payload", _capture_payload)
+
+    df = pd.DataFrame(
+        [
+            {"Item": "Qty", "Example Values / Options": 1, "Data Type / Input Method": "number"},
+            {"Item": "FAIR Required", "Example Values / Options": "True", "Data Type / Input Method": "checkbox"},
+            {"Item": "Material Name", "Example Values / Options": "6061-T6 Aluminum", "Data Type / Input Method": "text"},
+            {"Item": "Net Volume (cm^3)", "Example Values / Options": 50, "Data Type / Input Method": "number"},
+            {"Item": "Thickness (in)", "Example Values / Options": 1.0, "Data Type / Input Method": "number"},
+        ]
+    )
+
+    result = appV5.compute_quote_from_df(df, llm_enabled=False)
+
+    baseline = result["decision_state"]["baseline"]
+    assert baseline.get("fai_required") is True
+    assert isinstance(baseline.get("fai_required"), bool)
+
+    derived = captured["geo"]["derived"]
+    assert derived.get("fai_required") is True
+    assert isinstance(derived.get("fai_required"), bool)


### PR DESCRIPTION
## Summary
- ensure FAIR Required checkbox uses checkbox coercion when seeding baseline data and feature payloads
- add a regression test that verifies "FAIR Required" strings map to boolean `True`

## Testing
- pytest tests/app/test_fai_checkbox.py -q


------
https://chatgpt.com/codex/tasks/task_e_68de7d149e608320a282382f283dcbd7