### PR TITLE
Integrate process planning into quote engine

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -133,6 +133,12 @@ from cad_quoter.llm import (
     SYSTEM_SUGGEST,
 )
 
+try:
+    from process_planner import plan_job as _process_plan_job
+except Exception:  # pragma: no cover - planner is optional at runtime
+    _process_plan_job = None
+
+
 # Mapping of process keys to editor labels for propagating derived hours from
 # LLM suggestions. The scale term allows lightweight conversions if we need to
 # express the hour totals in another unit for a given field.
@@ -5681,6 +5687,10 @@ def compute_quote_from_df(df: pd.DataFrame,
     inner_geo = dict(inner_geo_raw) if isinstance(inner_geo_raw, dict) else {}
     geo_context["geo"] = inner_geo
 
+    plate_length_in_val: float | None = None
+    plate_width_in_val: float | None = None
+    plate_thickness_in_val: float | None = None
+
     def _int_from(value: Any) -> int:
         num = _coerce_float_or_none(value)
         if num is None:
@@ -5994,6 +6004,10 @@ def compute_quote_from_df(df: pd.DataFrame,
             if t_in is not None:
                 thickness_mm_val = float(t_in) * 25.4
         thickness_mm_val = float(thickness_mm_val or 0.0)
+        if length_in_val and length_in_val > 0:
+            plate_length_in_val = float(length_in_val)
+        if width_in_val and width_in_val > 0:
+            plate_width_in_val = float(width_in_val)
         if thickness_mm_val > 0:
             geo_context["thickness_mm"] = thickness_mm_val
         length_mm = float(length_in_val or 0.0) * 25.4
@@ -6068,6 +6082,15 @@ def compute_quote_from_df(df: pd.DataFrame,
                 vol_cm3 = max(vol_cm3, vol_cm3_net)
                 GEO_vol_mm3 = max(GEO_vol_mm3, vol_cm3_net * 1000.0)
                 geo_context.setdefault("net_volume_cm3", float(vol_cm3_net))
+
+        if thickness_mm_val > 0:
+            plate_thickness_in_val = float(thickness_mm_val) / 25.4
+        elif thickness_in_for_mass and thickness_in_for_mass > 0:
+            plate_thickness_in_val = float(thickness_in_for_mass)
+        else:
+            t_in_hint = _coerce_float_or_none(ui_vars.get("Thickness (in)"))
+            if t_in_hint and t_in_hint > 0:
+                plate_thickness_in_val = float(t_in_hint)
 
     if density_g_cc and density_g_cc > 0:
         geo_context.setdefault("density_g_cc", float(density_g_cc))
@@ -6743,7 +6766,10 @@ def compute_quote_from_df(df: pd.DataFrame,
     }
     if fixture_plan_desc:
         baseline_data["fixture"] = fixture_plan_desc
+    if process_plan_summary:
+        baseline_data["process_plan"] = copy.deepcopy(process_plan_summary)
     quote_state.baseline = baseline_data
+    quote_state.process_plan = copy.deepcopy(process_plan_summary)
 
     def _clean_stock_entry(entry: dict[str, Any]) -> dict[str, Any]:
         cleaned: dict[str, Any] = {}
@@ -6910,6 +6936,202 @@ def compute_quote_from_df(df: pd.DataFrame,
             setup_hint["fixture_build_hr"] = _coerce_float_or_none(fix_detail.get("build_hr"))
         if setup_hint:
             features["fixture_plan"] = setup_hint
+
+    process_plan_summary: dict[str, Any] = {}
+    if _process_plan_job is not None:
+        def _compact_dict(data: dict[str, Any]) -> dict[str, Any]:
+            cleaned: dict[str, Any] = {}
+            for key, value in data.items():
+                if value is None:
+                    continue
+                if isinstance(value, (list, tuple)) and not value:
+                    continue
+                if isinstance(value, dict) and not value:
+                    continue
+                cleaned[key] = value
+            return cleaned
+
+        def _first_numeric(patterns: tuple[str, ...], *sources: Mapping[str, Any]) -> float | None:
+            for source in sources:
+                if not isinstance(source, Mapping):
+                    continue
+                for label, raw_value in source.items():
+                    key = str(label)
+                    if any(re.search(pattern, key, re.IGNORECASE) for pattern in patterns):
+                        num = _coerce_float_or_none(raw_value)
+                        if num is not None:
+                            return float(num)
+            return None
+
+        def _first_text(patterns: tuple[str, ...], *sources: Mapping[str, Any]) -> str | None:
+            for source in sources:
+                if not isinstance(source, Mapping):
+                    continue
+                for label, raw_value in source.items():
+                    key = str(label)
+                    if any(re.search(pattern, key, re.IGNORECASE) for pattern in patterns):
+                        text = str(raw_value).strip()
+                        if text:
+                            return text
+            return None
+
+        def _count_from_ui(patterns: tuple[str, ...]) -> int:
+            val = _first_numeric(patterns, ui_vars)
+            if val is None:
+                return 0
+            try:
+                qty = int(round(val))
+            except Exception:
+                return 0
+            return qty if qty > 0 else 0
+
+        planner_family: str | None = None
+        planner_inputs: dict[str, Any] | None = None
+
+        if is_plate_2d:
+            planner_family = "die_plate"
+            inputs: dict[str, Any] = {
+                "material": material_name or default_material_display,
+                "qty": int(Qty),
+            }
+            if plate_length_in_val and plate_width_in_val:
+                inputs["plate_LxW"] = [float(plate_length_in_val), float(plate_width_in_val)]
+            if plate_thickness_in_val and plate_thickness_in_val > 0:
+                inputs["thickness"] = float(plate_thickness_in_val)
+
+            flatness_spec = _first_numeric((r"flatness",), tolerance_inputs, ui_vars)
+            if flatness_spec is not None:
+                inputs["flatness_spec"] = float(flatness_spec)
+
+            parallelism_spec = _first_numeric((r"parallel",), tolerance_inputs, ui_vars)
+            if parallelism_spec is not None:
+                inputs["parallelism_spec"] = float(parallelism_spec)
+
+            profile_tol = _first_numeric((r"profile",), tolerance_inputs, ui_vars)
+            if profile_tol is not None:
+                inputs["profile_tol"] = float(profile_tol)
+
+            corner_radius = _first_numeric((r"(corner|inside).*(radius|r)",), tolerance_inputs, ui_vars)
+            if corner_radius is not None:
+                inputs["window_corner_radius_req"] = float(corner_radius)
+
+            windows_need_sharp = bool(GEO_wedm_len_mm and GEO_wedm_len_mm > 0)
+            if not windows_need_sharp:
+                sharp_hint = _first_text((r"sharp", r"wedm"), ui_vars)
+                if sharp_hint:
+                    lowered = sharp_hint.lower()
+                    if "sharp" in lowered or "wedm" in lowered:
+                        windows_need_sharp = True
+            inputs["windows_need_sharp"] = bool(windows_need_sharp)
+
+            incoming_cut = str(geo_context.get("incoming_cut") or "").strip().lower()
+            if not incoming_cut:
+                incoming_text = _first_text((r"(incoming|blank).*(saw|water|flame|plasma|laser)", r"(saw|waterjet|flame|plasma|laser)"), ui_vars)
+                if incoming_text:
+                    lowered = incoming_text.lower()
+                    if "water" in lowered:
+                        incoming_cut = "waterjet"
+                    elif any(token in lowered for token in ("flame", "oxy", "plasma")):
+                        incoming_cut = "flame"
+                    elif "laser" in lowered:
+                        incoming_cut = "waterjet"
+                    elif "saw" in lowered or "band" in lowered:
+                        incoming_cut = "saw"
+            if incoming_cut not in {"saw", "waterjet", "flame"}:
+                incoming_cut = "saw"
+            inputs["incoming_cut"] = incoming_cut
+
+            stress_relief_risk = str(geo_context.get("stress_relief_risk") or "").strip().lower()
+            if not stress_relief_risk:
+                sr_text = _first_text((r"stress\s*relief", r"stress\s*risk"), ui_vars)
+                if sr_text:
+                    lowered = sr_text.lower()
+                    if "high" in lowered:
+                        stress_relief_risk = "high"
+                    elif "med" in lowered:
+                        stress_relief_risk = "med"
+                    elif "low" in lowered:
+                        stress_relief_risk = "low"
+            if stress_relief_risk == "medium":
+                stress_relief_risk = "med"
+            if stress_relief_risk not in {"low", "med", "high"}:
+                stress_relief_risk = "low"
+            inputs["stress_relief_risk"] = stress_relief_risk
+
+            marking_value: str | None = None
+            mark_text = _first_text((r"mark", r"engrave"), ui_vars)
+            if mark_text:
+                lowered = mark_text.lower()
+                if any(token in lowered for token in ("laser", "engrave", "etch")):
+                    marking_value = "laser"
+                elif "stamp" in lowered:
+                    marking_value = "stamp"
+                elif "none" in lowered:
+                    marking_value = "none"
+            if marking_value is None:
+                mark_hours = _coerce_float_or_none(ui_vars.get("Laser Marking / Engraving Time"))
+                if mark_hours and mark_hours > 0:
+                    marking_value = "laser"
+            if marking_value is None:
+                for label, value in ui_vars.items():
+                    if re.search(r"(laser\s*mark|engrave)", str(label), re.IGNORECASE):
+                        if _coerce_checkbox_state(value, False):
+                            marking_value = "laser"
+                            break
+            if marking_value is None:
+                marking_value = "none"
+            inputs["marking"] = marking_value
+
+            hole_sets: list[dict[str, Any]] = []
+            total_taps = 0
+            if isinstance(tap_class_counts_geo, dict):
+                for qty in tap_class_counts_geo.values():
+                    num = _coerce_float_or_none(qty)
+                    if num and num > 0:
+                        try:
+                            total_taps += int(round(num))
+                        except Exception:
+                            continue
+            if total_taps <= 0 and tap_qty_geo:
+                try:
+                    total_taps = int(round(float(tap_qty_geo)))
+                except Exception:
+                    total_taps = 0
+            if total_taps > 0:
+                hole_sets.append({"type": "tapped", "qty": total_taps})
+
+            dowel_press_qty = _count_from_ui((r"dowel.*press", r"press.*dowel"))
+            if dowel_press_qty:
+                hole_sets.append({"type": "dowel_press", "qty": dowel_press_qty})
+
+            dowel_slip_qty = _count_from_ui((r"dowel.*slip", r"slip.*dowel"))
+            if dowel_slip_qty:
+                hole_sets.append({"type": "dowel_slip", "qty": dowel_slip_qty})
+
+            if hole_sets:
+                inputs["hole_sets"] = hole_sets
+
+            planner_inputs = _compact_dict(inputs)
+
+        if planner_family and planner_inputs:
+            try:
+                planner_result = _process_plan_job(planner_family, planner_inputs)
+            except Exception as planner_err:  # pragma: no cover - defensive logging
+                logger.debug("Process planner failed for %s: %s", planner_family, planner_err)
+                process_plan_summary = {
+                    "family": planner_family,
+                    "inputs": planner_inputs,
+                    "error": str(planner_err),
+                }
+            else:
+                process_plan_summary = {
+                    "family": planner_family,
+                    "inputs": planner_inputs,
+                    "plan": planner_result,
+                }
+
+    if process_plan_summary:
+        features["process_plan"] = copy.deepcopy(process_plan_summary)
 
     base_costs = {
         "process_costs": process_costs_baseline,
@@ -8098,6 +8320,8 @@ def compute_quote_from_df(df: pd.DataFrame,
         llm_cost_log["usage"] = overrides_meta["usage"]
     if notes_from_clamps:
         llm_cost_log["clamp_notes"] = notes_from_clamps
+    if process_plan_summary:
+        llm_cost_log["process_plan"] = copy.deepcopy(process_plan_summary)
     if applied_multipliers_log:
         llm_cost_log["applied_multipliers"] = applied_multipliers_log
     if applied_adders_log:
@@ -8154,6 +8378,9 @@ def compute_quote_from_df(df: pd.DataFrame,
         "llm_cost_log": llm_cost_log,
     }
 
+    if process_plan_summary:
+        breakdown["process_plan"] = copy.deepcopy(process_plan_summary)
+
     decision_state = {
         "baseline": copy.deepcopy(quote_state.baseline),
         "suggestions": copy.deepcopy(quote_state.suggestions),
@@ -8203,6 +8430,7 @@ def compute_quote_from_df(df: pd.DataFrame,
         "decision_state": decision_state,
         "geo": copy.deepcopy(quote_state.geo),
         "ui_vars": copy.deepcopy(quote_state.ui_vars),
+        "process_plan": copy.deepcopy(quote_state.process_plan),
         "material_source": material_source_final,
     }
 

--- a/cad_quoter/domain_models/state.py
+++ b/cad_quoter/domain_models/state.py
@@ -62,6 +62,7 @@ class QuoteState:
     bounds: dict[str, Any] = field(default_factory=dict)
     material_source: str | None = None
     guard_context: dict[str, Any] = field(default_factory=dict)
+    process_plan: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise the entire state tree to plain Python structures."""
@@ -94,6 +95,7 @@ class QuoteState:
             "accept_llm",
             "bounds",
             "guard_context",
+            "process_plan",
         }
 
         kwargs: dict[str, Any] = {}

--- a/process_planner.py
+++ b/process_planner.py
@@ -1,0 +1,412 @@
+"""Process planning rules engine for machining families.
+
+This module provides helper functions and planner entry points for several
+process families used in the CAD quoting tool.  Each planner returns a
+dictionary containing a list of operations (`ops`) as well as notes for
+fixturing, quality assurance, and warnings.  The logic is based on the rules
+supplied in the Composidie EDM and grinding reference playbook.
+"""
+
+from math import isfinite
+from typing import Any, Dict, List, Optional
+
+Op = Dict[str, Any]
+Plan = Dict[str, Any]
+
+
+# -----------------------------
+# Shared helpers / guardrails
+# -----------------------------
+
+
+def _safe(v, default=None):
+    return v if v is not None else default
+
+
+def choose_wire_size(
+    min_inside_radius: Optional[float], min_feature_width: Optional[float]
+) -> float:
+    """Return wire diameter (inches)."""
+
+    mir = _safe(min_inside_radius, 1.0)
+    mfw = _safe(min_feature_width, 1.0)
+    wire = 0.010
+    if mir <= 0.005 or mfw <= 0.020:
+        wire = 0.008
+    if mir <= 0.0035 or mfw <= 0.012:
+        wire = 0.006
+    return wire
+
+
+def choose_skims(profile_tol: Optional[float]) -> int:
+    """Return number of skim passes for WEDM."""
+
+    pt = _safe(profile_tol, 0.0015)
+    if pt <= 0.0002:
+        return 3
+    if pt <= 0.0003:
+        return 2
+    if pt <= 0.0005:
+        return 1
+    return 0
+
+
+def needs_wedm_for_windows(
+    windows_need_sharp: bool,
+    window_corner_radius_req: Optional[float],
+    profile_tol: Optional[float],
+) -> bool:
+    r = _safe(window_corner_radius_req, 999)
+    t = _safe(profile_tol, 999)
+    return bool(windows_need_sharp or r <= 0.030 or t <= 0.001)
+
+
+def add(plan: Plan, op: str, **params) -> None:
+    plan["ops"].append({"op": op, **({k: v for k, v in params.items() if v is not None})})
+
+
+def base_plan() -> Plan:
+    return {"ops": [], "fixturing": [], "qa": [], "warnings": []}
+
+
+def warn(plan: Plan, msg: str) -> None:
+    plan["warnings"].append(msg)
+
+
+def add_fixturing(plan: Plan, note: str) -> None:
+    plan["fixturing"].append(note)
+
+
+def add_qa(plan: Plan, note: str) -> None:
+    plan["qa"].append(note)
+
+
+# -----------------------------
+# FAMILY 1: DIE PLATES / SHOES / FLATS / PROFILES
+# -----------------------------
+
+
+def plan_die_plate(p: Dict[str, Any]) -> Plan:
+    """Generate a plan for die plates, shoes, flats, or profiles."""
+
+    plan = base_plan()
+
+    material = p.get("material", "4140PH")
+    L, W = p.get("plate_LxW", (0, 0))
+    incoming = p.get("incoming_cut", "saw")
+    flatness_spec = p.get("flatness_spec")
+    parallelism_spec = p.get("parallelism_spec")
+    profile_tol = p.get("profile_tol")
+    windows_need_sharp = bool(p.get("windows_need_sharp", False))
+    corner_r = p.get("window_corner_radius_req")
+    stress_risk = p.get("stress_relief_risk", "low")
+
+    # A) Stability
+    if incoming == "flame" or stress_risk != "low":
+        add(plan, "stress_relieve")
+        add_fixturing(plan, "Use leveling blocks; record height change pre/post SR.")
+
+    # B) Faces (Blanchard vs face-mill + final SG)
+    large_plate = max(L, W) > 10
+    tight_flat = (flatness_spec is not None) and (flatness_spec <= 0.001)
+    if large_plate or tight_flat:
+        add(plan, "blanchard_grind_pre", leave_total=0.010)
+    else:
+        add(plan, "face_mill_pre")
+
+    # C) Rough CNC
+    add(plan, "cnc_rough_mill", stock_wall=0.010, stock_floor=0.010)
+    add(plan, "spot_drill_all")
+    add(plan, "drill_patterns")
+    add(plan, "interpolate_critical_bores", undersize=0.010)
+
+    # D) Windows / profiles (WEDM vs finish-mill)
+    if needs_wedm_for_windows(windows_need_sharp, corner_r, profile_tol):
+        wire = choose_wire_size(corner_r, None)
+        skims = choose_skims(profile_tol)
+        add(plan, "wire_edm_windows", wire_in=wire, passes=f"R+{skims}S", tab_slugs=True)
+        add_fixturing(plan, "Tab slugs; cut tabs after skim passes to minimize movement.")
+    else:
+        add(plan, "finish_mill_windows")
+
+    # E) Bores & fits
+    for h in p.get("hole_sets", []):
+        htype = h.get("type")
+        if htype in {"post_bore", "bushing_seat"}:
+            tol = h.get("tol", h.get("od_tol", 0.001))
+            if tol <= 0.0005 or h.get("coax_pair_id"):
+                add(plan, "assemble_pair_on_fixture")
+                add(plan, "jig_bore_or_jig_grind_coaxial_bores", tol=tol)
+                add_qa(plan, "Check coaxiality/runout over assembled height.")
+            else:
+                add(plan, "drill_ream_bore", tol=tol)
+        elif htype == "dowel_press":
+            add(plan, "drill_ream_dowel_press")
+        elif htype == "dowel_slip":
+            add(plan, "ream_slip_in_assembly")
+            add_qa(plan, "Verify slip-fit location after assembly ream.")
+        elif htype == "tapped":
+            dia = h.get("dia", 0.0)
+            depth = h.get("depth", 0.0)
+            use_tm = (dia >= 0.5) or (depth > 1.5 * dia)
+            add(plan, "thread_mill" if use_tm else "rigid_tap", dia=dia, depth=depth)
+
+    # F) Final faces
+    if (flatness_spec is not None) or (parallelism_spec is not None):
+        add(
+            plan,
+            "surface_grind_faces",
+            flatness_spec=flatness_spec,
+            parallelism_spec=parallelism_spec,
+        )
+        add_fixturing(plan, "Mag-chuck with ground backer; flip and relieve to avoid dish.")
+
+    # G) Stress loop check
+    add(plan, "stability_check_after_ops")
+    add_qa(plan, "Granite flatness map; CMM datums A/B/C; plug/ID mics on bores.")
+    add(plan, "edge_break", size=0.010)
+    if p.get("marking", "laser") != "none":
+        add(plan, "mark_id", method=p.get("marking", "laser"))
+
+    return plan
+
+
+# -----------------------------
+# FAMILY 2: PUNCHES & INSERTS (steel/carbide; flat/form/step/comb)
+# -----------------------------
+
+
+def plan_punch(p: Dict[str, Any]) -> Plan:
+    """Generate a plan for punches and inserts."""
+
+    plan = base_plan()
+
+    mat = p.get("material", "tool_steel_annealed")
+    overall_L = p.get("overall_length", 1.0)
+    mfw = p.get("min_feature_width", 1.0)
+    mir = p.get("min_inside_radius", 1.0)
+    profile_tol = p.get("profile_tol", 0.0005)
+    blind = bool(p.get("blind_relief", False))
+
+    # Material route
+    if mat == "carbide":
+        add(plan, "start_ground_carbide_blank")
+    elif mat == "tool_steel_annealed":
+        add(plan, "saw_blank")
+        add(plan, "cnc_mill_rough", stock=0.020)
+        add(plan, "surface_grind_datums")
+        add(plan, "heat_treat_to_spec")
+    else:  # tool_steel_HT
+        add(plan, "indicate_hardened_blank")
+
+    # Slenderness & carrier
+    slender = overall_L / max(mfw, 1e-6)
+    if slender >= 20 or mfw <= 0.020:
+        add_fixturing(plan, "Keep part tabbed to carrier for WEDM; support during grind.")
+        add(plan, "prep_carrier_or_tab")
+
+    # Wire EDM
+    wire = choose_wire_size(mir, mfw)
+    skims = choose_skims(profile_tol)
+    add(
+        plan,
+        "wire_edm_outline",
+        wire_in=wire,
+        passes=f"R+{skims}S",
+        tabbed=(slender >= 20 or mfw <= 0.020),
+    )
+
+    # Blind features via sinker
+    if blind:
+        elec = "copper" if (mir <= 0.005 or profile_tol <= 0.0003) else "graphite"
+        add(plan, "machine_electrode", material=elec)
+        add(plan, "sinker_edm_finish_burn")
+
+    # Bearing lands
+    bl = p.get("bearing_land_spec")
+    if bl:
+        add(
+            plan,
+            "surface_or_profile_grind_bearing",
+            land_width=bl.get("width"),
+            target_Ra=bl.get("Ra"),
+        )
+        add(plan, "lap_bearing_land", target_Ra=bl.get("Ra"))
+    else:
+        add(plan, "light_grind_cleanup")
+
+    # Pilots & runout
+    runout = p.get("runout_to_shank")
+    if runout is not None and runout <= 0.0003:
+        add(plan, "indicate_on_shank")
+        add(plan, "profile_grind_pilot_OD_to_TIR", TIR=runout)
+        add_qa(plan, "Check pilot OD TIR to shank on V-blocks or between centers.")
+
+    # Edge & coat
+    edge = p.get("edge_condition", "0.001R")
+    if edge != "sharp":
+        add(plan, "edge_prep", spec=edge)
+    if p.get("coating") not in (None, "none"):
+        add(plan, "clean_degas_for_coating")
+        add(plan, "apply_coating", type=p["coating"])
+
+    # QA
+    add_qa(plan, "Comparator profile vs CAD; measure land width & size; hardness if steel.")
+    return plan
+
+
+# -----------------------------
+# FAMILY 3: PILOT PUNCHES (wrapper over punches with concentricity)
+# -----------------------------
+
+
+def plan_pilot_punch(p: Dict[str, Any]) -> Plan:
+    p2 = dict(p)
+    p2.setdefault("runout_to_shank", 0.0003)
+    return plan_punch(p2)
+
+
+# -----------------------------
+# FAMILY 4: GUIDE BUSHINGS / RING GAUGES (ID-critical)
+# -----------------------------
+
+
+def plan_bushing_id_critical(p: Dict[str, Any]) -> Plan:
+    """Generate a plan for ID critical guide bushings or ring gauges."""
+
+    plan = base_plan()
+    if p.get("tight_od", True):
+        add(plan, "purchase_OD_ground_blank")
+        warn(
+            plan,
+            "No cylindrical/centerless grinder listed; outsource OD if OD is critical.",
+        )
+    else:
+        add(plan, "turn_or_mill_OD")
+        add(plan, "surface_or_profile_grind_OD_cleanup")
+
+    if p.get("create_id_by_wire_first", False):
+        add(plan, "wire_edm_open_ID", leave=0.005)
+    else:
+        add(plan, "drill_or_trepan_ID", leave=0.005)
+
+    add(plan, "jig_grind_ID_to_size_and_roundness", tol=0.0002)
+    if p.get("target_id_Ra", 16) <= 8:
+        add(plan, "lap_ID", target_Ra=p.get("target_id_Ra", 8))
+
+    add_qa(plan, "Calibrate ID with ring/plug masters; certify size & roundness.")
+    return plan
+
+
+# -----------------------------
+# FAMILY 5: CAMS & HEMMING COMPONENTS
+# -----------------------------
+
+
+def plan_cam_or_hemmer(p: Dict[str, Any]) -> Plan:
+    """Generate a plan for cams and hemming components."""
+
+    plan = base_plan()
+    add(plan, "saw_or_mill_rough_blocks")
+    if p.get("material", "tool_steel") in {"D2", "A2", "PM", "tool_steel"}:
+        add(plan, "heat_treat_if_wear_part")
+
+    if needs_wedm_for_windows(p.get("windows_need_sharp", False), 0.0, p.get("profile_tol")):
+        wire = choose_wire_size(0.0, None)
+        skims = choose_skims(p.get("profile_tol"))
+        add(plan, "wire_edm_cam_slot_or_profile", wire_in=wire, passes=f"R+{skims}S")
+    else:
+        add(plan, "finish_mill_cam_slot_or_profile")
+
+    add(plan, "profile_or_surface_grind_wear_faces")
+    add(plan, "jig_bore_or_grind_pivot_bores", tol=0.0005)
+    add_qa(plan, "Inspect cam path size/position; verify bore TIR and hardness.")
+    return plan
+
+
+# -----------------------------
+# FAMILY 6: SPECIALS
+# -----------------------------
+
+
+def plan_flat_die_chaser(p: Optional[Dict[str, Any]] = None) -> Plan:
+    plan = base_plan()
+    add(plan, "mill_or_wire_rough_form")
+    add(plan, "heat_treat")
+    add(plan, "profile_grind_flanks_and_reliefs_to_spec")
+    add(plan, "lap_edges")
+    add_qa(plan, "Comparator flank angle/lead; hardness; edge condition.")
+    return plan
+
+
+def plan_pm_compaction_die(p: Dict[str, Any]) -> Plan:
+    plan = base_plan()
+    add(plan, "start_ground_carbide_ring")
+    add(plan, "wire_edm_ID_leave", leave=0.005)
+    add(plan, "jig_grind_ID_to_tenths_and_straightness", tol=0.0001)
+    add(plan, "lap_bearing_land", target_Ra=8)
+    add_qa(plan, "Measure taper/straightness over depth; Ra on land.")
+    return plan
+
+
+def plan_shear_blade(p: Optional[Dict[str, Any]] = None) -> Plan:
+    plan = base_plan()
+    add(plan, "waterjet_or_saw_blanks")
+    add(plan, "heat_treat", material="A2/D2/PM")
+    add(plan, "profile_grind_cutting_edges_and_angles")
+    add(plan, "match_grind_set_for_gap_and_parallelism")
+    add(plan, "hone_edge")
+    add_qa(plan, "Parallelism & edge angle match; hardness.")
+    return plan
+
+
+def plan_extrude_hone(p: Dict[str, Any]) -> Plan:
+    plan = base_plan()
+    add(plan, "verify_connected_passage_and_masking")
+    add(plan, "abrasive_flow_polish", target_Ra=_safe(p.get("target_Ra"), 16))
+    add(plan, "clean_and_flush_media")
+    add_qa(plan, "Flow/pressure delta or Ra before/after report.")
+    return plan
+
+
+# -----------------------------
+# Convenience: registry & router
+# -----------------------------
+
+
+PLANNERS = {
+    "die_plate": plan_die_plate,
+    "punch": plan_punch,
+    "pilot_punch": plan_pilot_punch,
+    "bushing_id_critical": plan_bushing_id_critical,
+    "cam_or_hemmer": plan_cam_or_hemmer,
+    "flat_die_chaser": plan_flat_die_chaser,
+    "pm_compaction_die": plan_pm_compaction_die,
+    "shear_blade": plan_shear_blade,
+    "extrude_hone": plan_extrude_hone,
+}
+
+
+def plan_job(family: str, params: Dict[str, Any]) -> Plan:
+    fn = PLANNERS.get(family)
+    if not fn:
+        raise ValueError(f"Unknown family: {family}")
+    return fn(params)
+
+
+__all__ = [
+    "plan_job",
+    "plan_die_plate",
+    "plan_punch",
+    "plan_pilot_punch",
+    "plan_bushing_id_critical",
+    "plan_cam_or_hemmer",
+    "plan_flat_die_chaser",
+    "plan_pm_compaction_die",
+    "plan_shear_blade",
+    "plan_extrude_hone",
+    "choose_wire_size",
+    "choose_skims",
+    "needs_wedm_for_windows",
+]
+


### PR DESCRIPTION
## Summary
- integrate the process planner for 2D die plates into the quoting flow and surface the generated plan alongside quote results
- persist planner inputs/results on the baseline quote data, decision state, and API response for downstream consumers
- extend QuoteState with a process_plan mapping so sessions serialize/deserialise planner output

## Testing
- pytest *(fails: import file mismatch between tests/test_material_density.py and tests/app/test_material_density.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d332e668832080949b629708030a