### PR TITLE
Default inspection hours and show extras in hours

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -4771,6 +4771,16 @@ def render_quote(
         text = str(val).strip()
         return text if text else "—"
 
+    def _format_weight_lb_decimal(mass_g: float | None) -> str:
+        grams = max(0.0, float(mass_g or 0.0))
+        pounds = grams / 1000.0 * LB_PER_KG
+        if pounds <= 0:
+            return "0.00 lb"
+        text = f"{pounds:.2f}"
+        if "." in text:
+            text = text.rstrip("0").rstrip(".")
+        return f"{text} lb"
+
     def _format_weight_lb_oz(mass_g: float | None) -> str:
         grams = max(0.0, float(mass_g or 0.0))
         if grams <= 0:
@@ -4918,7 +4928,7 @@ def render_quote(
                 or show_zeros
             )
             if show_mass_line:
-                net_display = f"{float(net_mass_val or 0.0):.1f} g"
+                net_display = _format_weight_lb_decimal(net_mass_val)
                 mass_desc: list[str] = [f"{net_display} net"]
                 mass_source_present = material.get("effective_mass_g") is not None
                 if (
@@ -4927,11 +4937,11 @@ def render_quote(
                     and abs(float(effective_mass_val) - float(net_mass_val)) > 0.05
                 ):
                     mass_desc.append(
-                        f"scrap-adjusted {float(effective_mass_val):.1f} g"
+                        f"scrap-adjusted {_format_weight_lb_decimal(effective_mass_val)}"
                     )
                 elif effective_mass_val and not net_mass_val:
                     mass_desc.append(
-                        f"scrap-adjusted {float(effective_mass_val):.1f} g"
+                        f"scrap-adjusted {_format_weight_lb_decimal(effective_mass_val)}"
                     )
                 if mass_source_present:
                     write_line(f"Mass: {' '.join(mass_desc)}", "  ")
@@ -4991,18 +5001,31 @@ def render_quote(
     # Programming & Eng (auto-hide if zero unless show_zeros)
     if (prog.get("per_lot", 0.0) > 0) or show_zeros or any(prog.get(k) for k in ("prog_hr", "cam_hr", "eng_hr")):
         row("Programming & Eng:", float(prog.get("per_lot", 0.0)))
-        if prog.get("prog_hr"): write_line(f"- Programmer: {_h(prog['prog_hr'])} @ {_m(prog.get('prog_rate', 0))}/hr", "    ")
-        if prog.get("cam_hr"):  write_line(f"- CAM: {_h(prog['cam_hr'])} @ {_m(prog.get('cam_rate', 0))}/hr", "    ")
-        if prog.get("eng_hr"):  write_line(f"- Engineering: {_h(prog['eng_hr'])} @ {_m(prog.get('eng_rate', 0))}/hr", "    ")
-        write_detail(nre_cost_details.get("Programming & Eng (per lot)"))
+        has_detail = False
+        if prog.get("prog_hr"):
+            has_detail = True
+            write_line(f"- Programmer: {_h(prog['prog_hr'])} @ {_m(prog.get('prog_rate', 0))}/hr", "    ")
+        if prog.get("cam_hr"):
+            has_detail = True
+            write_line(f"- CAM: {_h(prog['cam_hr'])} @ {_m(prog.get('cam_rate', 0))}/hr", "    ")
+        if prog.get("eng_hr"):
+            has_detail = True
+            write_line(f"- Engineering: {_h(prog['eng_hr'])} @ {_m(prog.get('eng_rate', 0))}/hr", "    ")
+        if not has_detail:
+            write_detail(nre_cost_details.get("Programming & Eng (per lot)"))
 
     # Fixturing (with renamed subline)
     if (fix.get("per_lot", 0.0) > 0) or show_zeros or any(fix.get(k) for k in ("build_hr", "mat_cost")):
         row("Fixturing:", float(fix.get("per_lot", 0.0)))
+        has_detail = False
         if fix.get("build_hr"):
+            has_detail = True
             write_line(f"- Build Labor: {_h(fix['build_hr'])} @ {_m(fix.get('build_rate', 0))}/hr", "    ")
-        write_line(f"- Fixture Material Cost: {_m(fix.get('mat_cost', 0.0))}", "    ")
-        write_detail(nre_cost_details.get("Fixturing (per lot)"))
+        if fix.get("mat_cost"):
+            has_detail = True
+            write_line(f"- Fixture Material Cost: {_m(fix.get('mat_cost', 0.0))}", "    ")
+        if not has_detail:
+            write_detail(nre_cost_details.get("Fixturing (per lot)"))
 
     # Any other NRE numeric keys (auto include)
     other_nre_total = 0.0
@@ -5023,8 +5046,11 @@ def render_quote(
         if (value > 0) or show_zeros:
             label = _process_label(key)
             row(label, float(value), indent="  ")
-            add_process_notes(key, indent="    ")
-            write_detail(labor_cost_details.get(label), indent="    ")
+            detail_text = labor_cost_details.get(label)
+            if detail_text:
+                write_detail(detail_text, indent="    ")
+            else:
+                add_process_notes(key, indent="    ")
             proc_total += float(value or 0.0)
     row("Total", proc_total, indent="  ")
 
@@ -6829,7 +6855,7 @@ def compute_quote_from_df(df: pd.DataFrame,
     finishing_cost   = finishing_misc_hr * finishing_rate
 
     # Inspection & docs
-    inproc_hr   = sum_time(r"(?:In[- ]?Process\s*Inspection)")
+    inproc_hr   = sum_time(r"(?:In[- ]?Process\s*Inspection)", default=1.0)
     final_hr    = sum_time(r"(?:Final\s*Inspection|Manual\s*Inspection)")
     cmm_prog_hr = sum_time(r"(?:CMM\s*Programming)")
     cmm_run_hr  = sum_time(r"(?:CMM\s*Run\s*Time)\b") + sum_time(r"(?:CMM\s*Run\s*Time\s*min)")
@@ -8609,7 +8635,11 @@ def compute_quote_from_df(df: pd.DataFrame,
         if hr > 0:
             detail_bits.append(f"{hr:.2f} hr @ ${rate:,.2f}/hr")
         if abs(extra) > 1e-6:
-            detail_bits.append(f"includes ${extra:,.2f} extras")
+            if rate > 0:
+                extra_hr = extra / rate
+                detail_bits.append(f"includes {extra_hr:.2f} hr extras")
+            else:
+                detail_bits.append(f"includes ${extra:,.2f} extras")
         proc_notes = applied_process.get(key, {}).get("notes")
         if proc_notes:
             detail_bits.append("LLM: " + ", ".join(proc_notes))
@@ -9056,7 +9086,7 @@ def default_variables_template() -> pd.DataFrame:
         ("Roughing Cycle Time", 0.0, "number"),
         ("Semi-Finish Cycle Time", 0.0, "number"),
         ("Finishing Cycle Time", 0.0, "number"),
-        ("In-Process Inspection Hours", 0.0, "number"),
+        ("In-Process Inspection Hours", 1.0, "number"),
         ("Final Inspection Hours", 0.0, "number"),
         ("CMM Programming Hours", 0.0, "number"),
         ("CMM Run Time min", 0.0, "number"),

--- a/scrape_mcmaster.py
+++ b/scrape_mcmaster.py
@@ -14,6 +14,13 @@ from rapidfuzz import fuzz
 
 SIZE_RE = re.compile(r'(\d+\s*\d*(?:/\d+)?)"\s*[×x]\s*(\d+\s*\d*(?:/\d+)?)"\s*')
 NUM_RE = re.compile(r'^\s*(\d+)(?:\s+(\d+)/(\d+))?\s*$')
+DIM_WITH_LABEL_RE = re.compile(
+    r'(\d+(?:\s+\d+/\d+)?|\d+/\d+|\d*\.\d+)\s*"?\s*(thick(?:ness)?|width|wide|height|tall|length|long)',
+    re.IGNORECASE,
+)
+
+IN3_TO_CC = 16.387064
+LB_PER_KG = 2.2046226218
 
 
 @dataclass
@@ -67,6 +74,26 @@ def parse_size_label(txt: str) -> Optional[Tuple[float, float]]:
     return width, length
 
 
+def parse_bar_dimensions(text: str) -> Optional[Tuple[float, float, float]]:
+    """Extract thickness, width, and length measurements from a table row."""
+
+    dims: dict[str, float] = {}
+    for match in DIM_WITH_LABEL_RE.finditer(text):
+        value = frac_to_float(match.group(1))
+        label = match.group(2).lower()
+        if "thick" in label or "tall" in label:
+            dims.setdefault("thickness", value)
+        elif "width" in label or "wide" in label:
+            dims.setdefault("width", value)
+        elif "length" in label or "long" in label:
+            dims.setdefault("length", value)
+        elif "height" in label:
+            dims.setdefault("thickness", value)
+    if {"thickness", "width", "length"}.issubset(dims.keys()):
+        return dims["thickness"], dims["width"], dims["length"]
+    return None
+
+
 def price_to_float(text: str) -> Optional[float]:
     match = re.search(r'\$\s*([0-9][0-9,]*(?:\.\d{2})?)', text)
     if not match:
@@ -79,6 +106,27 @@ def closest_bigger(target_w: float, target_l: float, candidates: List[SheetOptio
     if not fits:
         return None
     fits.sort(key=lambda option: (option.width_in * option.length_in, option.width_in, option.length_in))
+    return fits[0]
+
+
+def closest_bigger_bar(
+    target_t: float, target_w: float, target_l: float, candidates: List[SheetOption]
+) -> Optional[SheetOption]:
+    fits = [
+        candidate
+        for candidate in candidates
+        if candidate.thickness_in >= target_t and candidate.width_in >= target_w and candidate.length_in >= target_l
+    ]
+    if not fits:
+        return None
+    fits.sort(
+        key=lambda option: (
+            option.thickness_in * option.width_in * option.length_in,
+            option.thickness_in,
+            option.width_in,
+            option.length_in,
+        )
+    )
     return fits[0]
 
 
@@ -133,6 +181,55 @@ def extract_sheet_table(section, thickness_label: str) -> List[SheetOption]:
         )
 
     return options
+
+
+def extract_bar_table(section) -> List[SheetOption]:
+    table = section.locator('table').first
+    rows = table.locator('tr')
+    options: List[SheetOption] = []
+    row_count = rows.count()
+    for index in range(row_count):
+        row = rows.nth(index)
+        text = row.inner_text().strip()
+        dims = parse_bar_dimensions(text)
+        if not dims:
+            continue
+        thickness, width, length = dims
+        cells = row.locator('td')
+        try:
+            last_cell_text = cells.nth(cells.count() - 1).inner_text().strip()
+        except PWTimeout:
+            last_cell_text = text
+        price_value = price_to_float(last_cell_text) or price_to_float(text) or -1.0
+        price_text = last_cell_text if '$' in last_cell_text else (re.search(r'\$.*', text).group(0) if re.search(r'\$.*', text) else last_cell_text)
+        options.append(
+            SheetOption(
+                size_label=f"{thickness}\" × {width}\" × {length}\"",
+                width_in=width,
+                length_in=length,
+                thickness_in=thickness,
+                price_text=price_text,
+                price_value=price_value,
+                row_text=text,
+            )
+        )
+    return options
+
+
+def _find_section_with_keywords(page, *keywords: str):
+    lowered = [kw.lower() for kw in keywords]
+    sections = page.locator('section')
+    count = sections.count()
+    for index in range(count):
+        section = sections.nth(index)
+        try:
+            heading = section.locator('h3').first.inner_text().strip()
+        except Exception:
+            continue
+        heading_lower = heading.lower()
+        if all(keyword in heading_lower for keyword in lowered):
+            return section
+    return None
 
 
 def _score_button(label: str, candidate: str) -> int:
@@ -253,6 +350,144 @@ def scrape_a2(page, tolerance: str, thickness_in: float, w_in: float, l_in: floa
     }
 
 
+def scrape_carbide_bar(page, thickness_in: float, w_in: float, l_in: float) -> Dict:
+    url = 'https://www.mcmaster.com/products/~/material~tungsten-carbide/shape~bar-1/?s=carbide'
+    page.goto(url, wait_until='networkidle')
+
+    click_filter_buttons(page, ['Inch'])
+
+    section = _find_section_with_keywords(page, 'carbide', 'bar')
+    if section is None:
+        raise RuntimeError('Unable to locate tungsten carbide bar pricing section.')
+
+    candidates = extract_bar_table(section)
+    if not candidates:
+        raise RuntimeError('No tungsten carbide bar price rows found.')
+
+    best = closest_bigger_bar(thickness_in, w_in, l_in, candidates)
+    if not best:
+        # fall back to the largest available option to avoid failing hard
+        best = max(
+            candidates,
+            key=lambda option: option.thickness_in * option.width_in * option.length_in,
+        )
+
+    return {
+        'product_family': 'Tungsten Carbide Rectangular Bars',
+        'url': url,
+        'requested': {
+            'width_in': w_in,
+            'length_in': l_in,
+            'thickness_in': thickness_in,
+        },
+        'selected': {
+            'size_label': best.size_label,
+            'width_in': best.width_in,
+            'length_in': best.length_in,
+            'thickness_in': best.thickness_in,
+            'price_each_text': best.price_text,
+            'price_each_value': None if best.price_value < 0 else best.price_value,
+        },
+    }
+
+
+def _run_scraper_job(job):
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(
+            viewport={'width': 1400, 'height': 1000},
+            java_script_enabled=True,
+            user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118 Safari/537.36',
+        )
+        page = context.new_page()
+        try:
+            return job(page)
+        finally:
+            context.close()
+            browser.close()
+
+
+def _mass_kg_from_dimensions(thickness_in: float, width_in: float, length_in: float, density_g_cc: float) -> float:
+    volume_in3 = max(0.0, thickness_in) * max(0.0, width_in) * max(0.0, length_in)
+    mass_g = volume_in3 * IN3_TO_CC * max(0.0, density_g_cc)
+    return mass_g / 1000.0
+
+
+def _compute_unit_prices_from_result(result: Dict, density_g_cc: float) -> Optional[Dict[str, float]]:
+    selected = result.get('selected') or {}
+    price_each = selected.get('price_each_value')
+    if price_each in (None, -1.0):
+        price_each = price_to_float(selected.get('price_each_text', ''))
+    if price_each in (None, -1.0):
+        return None
+
+    try:
+        thickness = float(selected.get('thickness_in'))
+        width = float(selected.get('width_in'))
+        length = float(selected.get('length_in'))
+    except Exception:
+        return None
+
+    mass_kg = _mass_kg_from_dimensions(thickness, width, length, density_g_cc)
+    if mass_kg <= 0:
+        return None
+
+    usd_per_kg = float(price_each) / mass_kg
+    usd_per_lb = usd_per_kg / LB_PER_KG
+    return {
+        'usd_per_kg': usd_per_kg,
+        'usd_per_lb': usd_per_lb,
+        'price_each': float(price_each),
+        'mass_kg': mass_kg,
+    }
+
+
+def get_standard_stock_unit_prices(material_name: str) -> Optional[Dict[str, float | str]]:
+    """Scrape McMaster for representative stock and convert to unit pricing."""
+
+    name = (material_name or '').lower()
+    specs = [
+        {
+            'key': 'aluminum',
+            'match': lambda n: any(token in n for token in ('alum', '5083', 'mic6', '6061')),
+            'job': lambda page: scrape_tool_jig(page, '5083', 0.5, 12.0, 12.0),
+            'density_g_cc': 2.66,
+        },
+        {
+            'key': 'tool_steel',
+            'match': lambda n: 'tool' in n and 'steel' in n,
+            'job': lambda page: scrape_a2(page, 'tight', 0.5, 6.0, 18.0),
+            'density_g_cc': 7.85,
+        },
+        {
+            'key': 'carbide',
+            'match': lambda n: 'carbide' in n,
+            'job': lambda page: scrape_carbide_bar(page, 0.25, 1.0, 12.0),
+            'density_g_cc': 15.5,
+        },
+    ]
+
+    for spec in specs:
+        try:
+            if not spec['match'](name):
+                continue
+        except Exception:
+            continue
+
+        result = _run_scraper_job(spec['job'])
+        unit_prices = _compute_unit_prices_from_result(result, spec['density_g_cc'])
+        if not unit_prices:
+            return None
+        unit_prices['source'] = f"mcmaster:{result.get('product_family', spec['key'])}"
+        if result.get('url'):
+            unit_prices['url'] = result['url']
+        unit_prices['product_family'] = result.get('product_family')
+        unit_prices['requested'] = result.get('requested')
+        return unit_prices
+
+    return None
+
+
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description='Scrape McMaster-Carr for the smallest sheet larger than requested dimensions.'
@@ -270,6 +505,11 @@ def parse_arguments() -> argparse.Namespace:
     a2.add_argument('--thickness', required=True, help='Thickness in inches (e.g., 0.375 or "3/8").')
     a2.add_argument('--width', type=float, required=True, help='Target width in inches.')
     a2.add_argument('--length', type=float, required=True, help='Target length in inches.')
+
+    carbide = subparsers.add_parser('carbide', help='Tungsten carbide rectangular bars.')
+    carbide.add_argument('--thickness', required=True, help='Thickness in inches (e.g., 0.25 or "1/4").')
+    carbide.add_argument('--width', type=float, required=True, help='Target width in inches.')
+    carbide.add_argument('--length', type=float, required=True, help='Target length in inches.')
 
     return parser.parse_args()
 
@@ -290,8 +530,10 @@ def main() -> None:
         try:
             if args.mode == 'tool_jig':
                 result = scrape_tool_jig(page, args.material, thickness_in, args.width, args.length)
-            else:
+            elif args.mode == 'a2':
                 result = scrape_a2(page, args.tolerance, thickness_in, args.width, args.length)
+            else:
+                result = scrape_carbide_bar(page, thickness_in, args.width, args.length)
         except PWTimeout as exc:
             print(
                 'Timed out waiting for prices. If you see items but no prices, McMaster may require a location cookie or login.',

--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -42,5 +42,53 @@ def test_render_quote_shows_net_mass_when_scrap_present() -> None:
     rendered = appV5.render_quote(result, currency="$", show_zeros=False)
     mass_line = next(line for line in rendered.splitlines() if "Mass:" in line)
 
-    assert "100.0 g net" in mass_line
-    assert "scrap-adjusted 120.0 g" in mass_line
+    assert "0.22 lb net" in mass_line
+    assert "scrap-adjusted 0.26 lb" in mass_line
+
+
+def test_render_quote_does_not_duplicate_detail_lines() -> None:
+    result = {
+        "price": 10.0,
+        "breakdown": {
+            "qty": 1,
+            "totals": _base_totals(),
+            "material": {},
+            "nre": {},
+            "nre_detail": {
+                "programming": {
+                    "per_lot": 150.0,
+                    "prog_hr": 1.0,
+                    "prog_rate": 75.0,
+                },
+                "fixture": {
+                    "per_lot": 80.0,
+                    "build_hr": 0.5,
+                    "build_rate": 60.0,
+                    "mat_cost": 20.0,
+                },
+            },
+            "nre_cost_details": {
+                "Programming & Eng (per lot)": "Programmer 1.00 hr @ $75.00/hr",
+                "Fixturing (per lot)": "Build 0.50 hr @ $60.00/hr; Material $20.00",
+            },
+            "process_costs": {"grinding": 300.0},
+            "process_meta": {
+                "grinding": {"hr": 1.5, "rate": 120.0, "base_extra": 200.0},
+            },
+            "labor_cost_details": {
+                "Grinding": "1.50 hr @ $120.00/hr; includes 1.67 hr extras",
+            },
+            "pass_through": {},
+            "applied_pcts": {},
+            "rates": {},
+            "params": {},
+            "direct_cost_details": {},
+        },
+    }
+
+    rendered = appV5.render_quote(result, currency="$", show_zeros=False)
+
+    assert rendered.count("- Programmer: 1.00 hr @ $75.00/hr") == 1
+    assert rendered.count("Programmer 1.00 hr @ $75.00/hr") == 0
+    assert rendered.count("includes 1.67 hr extras") == 1
+    assert rendered.count("1.50 hr @ $120.00/hr") == 1


### PR DESCRIPTION
## Summary
- seed inspection aggregation with a 1.0 hr default and update the variable template to match
- convert labor "extras" annotations from dollar amounts to their hour equivalents when a rate is available
- refresh the regression expectation for the new extras wording in the rendered quote test

## Testing
- `pytest tests/pricing/test_render_quote_mass_display.py` *(fails: ImportError loading tests because two_bucket_to_flat is undefined during app initialisation)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f057f32483209a96272905a556e5