### PR TITLE
Remove CAM rate usage in favor of programming rate

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5000,15 +5000,12 @@ def render_quote(
     fix  = nre_detail.get("fixture") or {}
 
     # Programming & Eng (auto-hide if zero unless show_zeros)
-    if (prog.get("per_lot", 0.0) > 0) or show_zeros or any(prog.get(k) for k in ("prog_hr", "cam_hr", "eng_hr")):
+    if (prog.get("per_lot", 0.0) > 0) or show_zeros or any(prog.get(k) for k in ("prog_hr", "eng_hr")):
         row("Programming & Eng:", float(prog.get("per_lot", 0.0)))
         has_detail = False
         if prog.get("prog_hr"):
             has_detail = True
             write_line(f"- Programmer: {_h(prog['prog_hr'])} @ {_m(prog.get('prog_rate', 0))}/hr", "    ")
-        if prog.get("cam_hr"):
-            has_detail = True
-            write_line(f"- CAM: {_h(prog['cam_hr'])} @ {_m(prog.get('cam_rate', 0))}/hr", "    ")
         if prog.get("eng_hr"):
             has_detail = True
             write_line(f"- Engineering: {_h(prog['eng_hr'])} @ {_m(prog.get('eng_rate', 0))}/hr", "    ")
@@ -5194,7 +5191,6 @@ RATES_DEFAULT = two_bucket_to_flat(RATES_TWO_BUCKET_DEFAULT)
 
 LABOR_RATE_KEYS: set[str] = {
     "ProgrammingRate",
-    "CAMRate",
     "EngineerRate",
     "InspectionRate",
     "FinishingRate",
@@ -6339,7 +6335,6 @@ def compute_quote_from_df(df: pd.DataFrame,
             rates[key] = v
 
     rate_from_sheet(r"Rate\s*-\s*Programming",   "ProgrammingRate")
-    rate_from_sheet(r"Rate\s*-\s*CAM",           "CAMRate")
     rate_from_sheet(r"Rate\s*-\s*Engineer",      "EngineerRate")
     rate_from_sheet(r"Rate\s*-\s*Milling",       "MillingRate")
     rate_from_sheet(r"Rate\s*-\s*Turning",       "TurningRate")
@@ -6738,7 +6733,8 @@ def compute_quote_from_df(df: pd.DataFrame,
     if milling_hr > 0:
         prog_hr = min(prog_hr, params["ProgMaxToMillingRatio"] * milling_hr)
 
-    programming_cost   = prog_hr * rates["ProgrammingRate"] + cam_hr * rates["CAMRate"] + eng_hr * rates["EngineerRate"]
+    total_prog_hr = prog_hr + cam_hr
+    programming_cost   = total_prog_hr * rates["ProgrammingRate"] + eng_hr * rates["EngineerRate"]
     prog_per_lot       = programming_cost
     programming_per_part = (prog_per_lot / Qty) if (amortize_programming and Qty > 1) else prog_per_lot
 
@@ -6754,9 +6750,8 @@ def compute_quote_from_df(df: pd.DataFrame,
 
     nre_detail = {
         "programming": {
-            "prog_hr": float(prog_hr), "prog_rate": rates["ProgrammingRate"],
-            "cam_hr": float(cam_hr),   "cam_rate": rates["CAMRate"],
-            "eng_hr": float(eng_hr),   "eng_rate": rates["EngineerRate"],
+            "prog_hr": float(total_prog_hr), "prog_rate": rates["ProgrammingRate"],
+            "eng_hr": float(eng_hr),         "eng_rate": rates["EngineerRate"],
             "per_lot": prog_per_lot, "per_part": programming_per_part,
             "amortized": bool(amortize_programming and Qty > 1)
         },
@@ -8695,8 +8690,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         details = []
         if prog_detail.get("prog_hr"):
             details.append(f"Programmer {prog_detail['prog_hr']:.2f} hr @ ${prog_detail.get('prog_rate',0):,.2f}/hr")
-        if prog_detail.get("cam_hr"):
-            details.append(f"CAM {prog_detail['cam_hr']:.2f} hr @ ${prog_detail.get('cam_rate',0):,.2f}/hr")
         if prog_detail.get("eng_hr"):
             details.append(f"Engineer {prog_detail['eng_hr']:.2f} hr @ ${prog_detail.get('eng_rate',0):,.2f}/hr")
         if details:

--- a/cad_quoter/rates.py
+++ b/cad_quoter/rates.py
@@ -56,9 +56,14 @@ OLDKEY_TO_MACHINE = {
 }
 
 
+LEGACY_PROGRAMMER_RATE_KEYS = (
+    "ProgrammingRate",
+    "CAMRate",
+)
+
+
 OLDKEY_TO_LABOR = {
-    "ProgrammingRate": "Programmer",  # same as CAMRate below; we'll reconcile
-    "CAMRate": "Programmer",
+    "ProgrammingRate": "Programmer",
     "EngineerRate": "Engineer",
     "ProjectManagementRate": "ProjectManager",
     "ToolmakerSupportRate": "Toolmaker",
@@ -73,9 +78,9 @@ OLDKEY_TO_LABOR = {
 }
 
 
-# Preferred canonical role for overlapping keys (e.g., ProgrammingRate vs CAMRate)
+# Preferred canonical role names when flattening
 PREFERRED_ROLE_FOR_DUPES = {
-    "Programmer": ["ProgrammingRate", "CAMRate"],
+    "Programmer": ["ProgrammingRate"],
 }
 
 
@@ -85,12 +90,11 @@ def migrate_flat_to_two_bucket(old: Dict[str, float]) -> Dict[str, Dict[str, flo
     labor: Dict[str, float] = {}
     machine: Dict[str, float] = {}
 
-    # Resolve duplicate labor sources
-    for role, keys in PREFERRED_ROLE_FOR_DUPES.items():
-        for key in keys:
-            if key in old:
-                labor[role] = float(old[key])
-                break
+    # Resolve programmer rate (handle legacy CAMRate alias)
+    for key in LEGACY_PROGRAMMER_RATE_KEYS:
+        if key in old:
+            labor["Programmer"] = float(old[key])
+            break
 
     # Map remaining labor keys
     for key, role in OLDKEY_TO_LABOR.items():

--- a/tests/test_rates_module.py
+++ b/tests/test_rates_module.py
@@ -19,6 +19,14 @@ def test_migrate_flat_to_two_bucket_handles_aliases() -> None:
     assert migrated["machine"]["Blanchard"] == 115.0
 
 
+def test_migrate_flat_to_two_bucket_handles_cam_rate_only() -> None:
+    flat = {"CAMRate": 110.0}
+
+    migrated = rates.migrate_flat_to_two_bucket(flat)
+
+    assert migrated["labor"]["Programmer"] == 110.0
+
+
 def test_two_bucket_to_flat_prefers_known_keys() -> None:
     two_bucket = {
         "labor": {"Programmer": 130.0, "Machinist": 90.0},
@@ -30,6 +38,7 @@ def test_two_bucket_to_flat_prefers_known_keys() -> None:
     assert flat["ProgrammingRate"] == 130.0
     assert flat["WireEDMRate"] == 150.0
     assert flat["Machinist"] == 90.0
+    assert "CAMRate" not in flat
 
 
 def test_op_cost_combines_machine_and_labor_minutes() -> None:


### PR DESCRIPTION
## Summary
- consolidate CAM costing into the programming rate and stop requesting a separate CAM rate override
- expose the combined programming rate in quote breakdowns while keeping compatibility with legacy CAMRate inputs
- update unit tests to cover the legacy CAMRate alias and ensure flattened rates omit CAMRate

## Testing
- pytest tests/test_rates_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e402044db88320b405b4abc14cb78b