### PR TITLE
Remove redundant mass summary line from rendered quotes

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -4980,7 +4980,6 @@ def render_quote(
             if show_mass_line:
                 net_display = _format_weight_lb_decimal(net_mass_val)
                 mass_desc: list[str] = [f"{net_display} net"]
-                mass_source_present = material.get("effective_mass_g") is not None
                 if (
                     effective_mass_val
                     and net_mass_val
@@ -4993,8 +4992,6 @@ def render_quote(
                     mass_desc.append(
                         f"scrap-adjusted {_format_weight_lb_decimal(effective_mass_val)}"
                     )
-                if mass_source_present:
-                    write_line(f"Mass: {' '.join(mass_desc)}", "  ")
 
             if (net_mass_val and net_mass_val > 0) or show_zeros:
                 write_line(f"Net Weight: {_format_weight_lb_oz(net_mass_val)}", "  ")

--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -40,10 +40,10 @@ def test_render_quote_shows_net_mass_when_scrap_present() -> None:
     }
 
     rendered = appV5.render_quote(result, currency="$", show_zeros=False)
-    mass_line = next(line for line in rendered.splitlines() if "Mass:" in line)
 
-    assert "0.22 lb net" in mass_line
-    assert "scrap-adjusted 0.26 lb" in mass_line
+    assert "Mass:" not in rendered
+    assert "Net Weight: 3.5 oz" in rendered
+    assert "With Scrap: 4.2 oz" in rendered
 
 
 def test_render_quote_does_not_duplicate_detail_lines() -> None:


### PR DESCRIPTION
## Summary
- remove the redundant "Mass" line from the material section of rendered quotes
- update the unit test to confirm the net and scrap-adjusted weight lines remain without the summary

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py

------
https://chatgpt.com/codex/tasks/task_e_68e5adb3bbd8832095f5559fe7454bec