### PR TITLE
Allow manual override of programming hours from quote sheet

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -6494,6 +6494,7 @@ def compute_quote_from_df(df: pd.DataFrame,
     params["ProgCapHr"]                = sheet_num(r"\b(Programming\s*Cap\s*Hr)\b", params.get("ProgCapHr"))
     params["ProgSimpleDim_mm"]         = sheet_num(r"\b(Prog\s*Simple\s*Dim_mm)\b", params.get("ProgSimpleDim_mm"))
     params["ProgMaxToMillingRatio"]    = sheet_num(r"\b(Prog\s*Max\s*To\s*Milling\s*Ratio)\b", params.get("ProgMaxToMillingRatio"))
+    prog_hr_override = sheet_num(r"\b(Programming\s*(?:Override|Manual)(?:\s*H(?:ou)?rs?)?)\b", None)
     params["MillingConsumablesPerHr"]  = sheet_num(r"(?i)Milling\s*Consumables\s*/\s*Hr", params.get("MillingConsumablesPerHr"))
     params["TurningConsumablesPerHr"]  = sheet_num(r"(?i)Turning\s*Consumables\s*/\s*Hr", params.get("TurningConsumablesPerHr"))
     params["EDMConsumablesPerHr"]      = sheet_num(r"(?i)EDM\s*Consumables\s*/\s*Hr", params.get("EDMConsumablesPerHr"))
@@ -6881,7 +6882,10 @@ def compute_quote_from_df(df: pd.DataFrame,
             material_detail_for_breakdown["material_direct_cost"] = material_direct_cost
 
     # ---- programming / cam / dfm --------------------------------------------
-    prog_hr = sum_time(r"(?:Programming|2D\s*CAM|3D\s*CAM|Simulation|Verification|DFM|Setup\s*Sheets)", exclude_pattern=r"\bCMM\b")
+    prog_hr = sum_time(
+        r"(?:Programming|2D\s*CAM|3D\s*CAM|Simulation|Verification|DFM|Setup\s*Sheets)",
+        exclude_pattern=r"\b(?:CMM|Override|Manual)\b",
+    )
     cam_hr  = sum_time(r"(?:CAM\s*Programming|CAM\s*Sim|Post\s*Processing)")
     eng_hr  = sum_time(r"(?:Fixture\s*Design|Process\s*Sheet|Traveler|Documentation)")
 
@@ -6908,6 +6912,16 @@ def compute_quote_from_df(df: pd.DataFrame,
         prog_hr = min(prog_hr, params["ProgMaxToMillingRatio"] * milling_hr)
 
     total_prog_hr = prog_hr + cam_hr
+    auto_prog_hr = float(total_prog_hr)
+    prog_override_applied = False
+    if prog_hr_override is not None:
+        try:
+            override_val = max(0.0, float(prog_hr_override))
+        except Exception:
+            override_val = None
+        else:
+            total_prog_hr = override_val
+            prog_override_applied = True
     programming_cost   = total_prog_hr * rates["ProgrammingRate"] + eng_hr * rates["EngineerRate"]
     prog_per_lot       = programming_cost
     programming_per_part = (prog_per_lot / Qty) if (amortize_programming and Qty > 1) else prog_per_lot
@@ -6922,13 +6936,18 @@ def compute_quote_from_df(df: pd.DataFrame,
     fixture_labor_per_part = (fixture_labor_cost / Qty) if Qty > 1 else fixture_labor_cost
     fixture_per_part       = (fixture_cost / Qty) if Qty > 1 else fixture_cost
 
+    programming_detail = {
+        "prog_hr": float(total_prog_hr), "prog_rate": rates["ProgrammingRate"],
+        "eng_hr": float(eng_hr),         "eng_rate": rates["EngineerRate"],
+        "per_lot": prog_per_lot, "per_part": programming_per_part,
+        "amortized": bool(amortize_programming and Qty > 1)
+    }
+    if prog_override_applied:
+        programming_detail["override_applied"] = True
+        programming_detail["auto_prog_hr"] = auto_prog_hr
+
     nre_detail = {
-        "programming": {
-            "prog_hr": float(total_prog_hr), "prog_rate": rates["ProgrammingRate"],
-            "eng_hr": float(eng_hr),         "eng_rate": rates["EngineerRate"],
-            "per_lot": prog_per_lot, "per_part": programming_per_part,
-            "amortized": bool(amortize_programming and Qty > 1)
-        },
+        "programming": programming_detail,
         "fixture": {
             "build_hr": float(fixture_build_hr), "build_rate": rates["FixtureBuildRate"],
             "labor_cost": float(fixture_labor_cost),

--- a/tests/app/test_programming_override.py
+++ b/tests/app/test_programming_override.py
@@ -1,0 +1,67 @@
+from typing import Iterable, Tuple, Union
+
+import pandas as pd
+import pytest
+
+import appV5
+
+
+def _df(rows: Iterable[Tuple[str, Union[float, int, str], str]]) -> pd.DataFrame:
+    normalized = [
+        {
+            "Item": item,
+            "Example Values / Options": value,
+            "Data Type / Input Method": dtype,
+        }
+        for item, value, dtype in rows
+    ]
+    return pd.DataFrame(normalized, columns=["Item", "Example Values / Options", "Data Type / Input Method"])
+
+
+def test_programming_hours_override_caps_total_hours() -> None:
+    df = _df(
+        [
+            ("Qty", 1, "number"),
+            ("Material", "6061", "text"),
+            ("Stock Thickness_mm", 25.4, "number"),
+            ("Prog Max To Milling Ratio", 100.0, "number"),
+            ("Programming Hours", 11.75, "number"),
+            ("Programming Override Hr", 1.0, "number"),
+        ]
+    )
+
+    result = appV5.compute_quote_from_df(
+        df,
+        llm_enabled=False,
+        geo={"thickness_mm": 25.4, "material": "6061"},
+    )
+
+    prog_detail = result["breakdown"]["nre_detail"]["programming"]
+
+    assert prog_detail["prog_hr"] == pytest.approx(1.0)
+    assert prog_detail["override_applied"] is True
+    assert prog_detail["auto_prog_hr"] == pytest.approx(11.75)
+
+
+def test_programming_hours_without_override_unmodified() -> None:
+    df = _df(
+        [
+            ("Qty", 1, "number"),
+            ("Material", "6061", "text"),
+            ("Stock Thickness_mm", 25.4, "number"),
+            ("Prog Max To Milling Ratio", 100.0, "number"),
+            ("Programming Hours", 11.75, "number"),
+        ]
+    )
+
+    result = appV5.compute_quote_from_df(
+        df,
+        llm_enabled=False,
+        geo={"thickness_mm": 25.4, "material": "6061"},
+    )
+
+    prog_detail = result["breakdown"]["nre_detail"]["programming"]
+
+    assert prog_detail["prog_hr"] == pytest.approx(11.75)
+    assert "override_applied" not in prog_detail
+    assert "auto_prog_hr" not in prog_detail


### PR DESCRIPTION
## Summary
- add support for a "Programming Override Hr" row so sheet authors can clamp programmer hours
- exclude the override row from automatic time aggregation and surface when an override is applied
- add unit tests covering the overridden and default programming hour calculations

## Testing
- pytest tests/app/test_programming_override.py

------
https://chatgpt.com/codex/tasks/task_e_68e5ae821e34832096e7d3ac4affb478