### PR TITLE
Display flat grinding extras without converting to hours

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5109,12 +5109,12 @@ def render_quote(
                 extra_val = 0.0
             if hr_val > 0:
                 detail_bits.append(f"{hr_val:.2f} hr @ ${rate_val:,.2f}/hr")
-            if abs(extra_val) > 1e-6:
-                if rate_val > 0:
-                    extra_hr = extra_val / rate_val
-                    detail_bits.append(f"includes {extra_hr:.2f} hr extras")
-                else:
-                    detail_bits.append(f"includes ${extra_val:,.2f} extras")
+        if abs(extra_val) > 1e-6:
+            if rate_val > 0 and hr_val > 0:
+                extra_hr = extra_val / rate_val
+                detail_bits.append(f"includes {extra_hr:.2f} hr extras")
+            else:
+                detail_bits.append(f"includes ${extra_val:,.2f} extras")
             proc_notes = applied_process.get(str(key).lower(), {}).get("notes")
             if proc_notes:
                 detail_bits.append("LLM: " + ", ".join(proc_notes))
@@ -9222,13 +9222,9 @@ def compute_quote_from_df(df: pd.DataFrame,
             detail_bits.append(f"{hr:.2f} hr")
 
         if abs(extra) > 1e-6:
-            if rate > 0:
+            if rate > 0 and hr > 0:
                 extra_hr = extra / rate if rate else 0.0
-                if hr == 0:
-                    # When there are only extra charges (e.g., Grinding), display as standard hours @ rate
-                    detail_bits.append(f"{extra_hr:.2f} hr @ ${rate:,.2f}/hr")
-                else:
-                    detail_bits.append(f"includes {extra_hr:.2f} hr extras")
+                detail_bits.append(f"includes {extra_hr:.2f} hr extras")
             else:
                 detail_bits.append(f"includes ${extra:,.2f} extras")
 

--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -94,3 +94,32 @@ def test_render_quote_does_not_duplicate_detail_lines() -> None:
     assert rendered.count("includes $200.00 extras") == 1
     assert rendered.count("includes 1.67 hr extras") == 1
     assert rendered.count("1.50 hr @ $120.00/hr") == 1
+
+
+def test_render_quote_shows_flat_extras_when_no_hours() -> None:
+    result = {
+        "price": 10.0,
+        "breakdown": {
+            "qty": 1,
+            "totals": _base_totals(),
+            "material": {},
+            "nre": {},
+            "nre_detail": {},
+            "nre_cost_details": {},
+            "process_costs": {"grinding": 200.0},
+            "process_meta": {
+                "grinding": {"hr": 0.0, "rate": 90.0, "base_extra": 200.0},
+            },
+            "labor_cost_details": {},
+            "pass_through": {},
+            "applied_pcts": {},
+            "rates": {},
+            "params": {},
+            "direct_cost_details": {},
+        },
+    }
+
+    rendered = appV5.render_quote(result, currency="$", show_zeros=False)
+
+    assert rendered.count("includes $200.00 extras") == 1
+    assert "hr extras" not in rendered


### PR DESCRIPTION
## Summary
- stop converting flat process extras into synthetic hours when no labor time was recorded for the process
- add a regression test ensuring grinding extras with zero hours stay dollar-denominated

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py

------
https://chatgpt.com/codex/tasks/task_e_68e5af346c388320868f1482821b15a1