### PR TITLE
Remove extra-hour detail line from quotes

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5110,9 +5110,9 @@ def render_quote(
             if hr_val > 0:
                 detail_bits.append(f"{hr_val:.2f} hr @ ${rate_val:,.2f}/hr")
             if abs(extra_val) > 1e-6:
-                if rate_val > 0:
-                    extra_hr = extra_val / rate_val
-                    detail_bits.append(f"includes {extra_hr:.2f} hr extras")
+                if rate_val > 0 and hr_val <= 0:
+                    extra_hr = extra_val / rate_val if rate_val else 0.0
+                    detail_bits.append(f"{extra_hr:.2f} hr @ ${rate_val:,.2f}/hr")
                 else:
                     detail_bits.append(f"includes ${extra_val:,.2f} extras")
             proc_notes = applied_process.get(str(key).lower(), {}).get("notes")
@@ -9222,13 +9222,10 @@ def compute_quote_from_df(df: pd.DataFrame,
             detail_bits.append(f"{hr:.2f} hr")
 
         if abs(extra) > 1e-6:
-            if rate > 0:
+            if rate > 0 and hr == 0:
                 extra_hr = extra / rate if rate else 0.0
-                if hr == 0:
-                    # When there are only extra charges (e.g., Grinding), display as standard hours @ rate
-                    detail_bits.append(f"{extra_hr:.2f} hr @ ${rate:,.2f}/hr")
-                else:
-                    detail_bits.append(f"includes {extra_hr:.2f} hr extras")
+                # When there are only extra charges (e.g., Grinding), display as standard hours @ rate
+                detail_bits.append(f"{extra_hr:.2f} hr @ ${rate:,.2f}/hr")
             else:
                 detail_bits.append(f"includes ${extra:,.2f} extras")
 

--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -92,5 +92,5 @@ def test_render_quote_does_not_duplicate_detail_lines() -> None:
     assert rendered.count("- Programmer: 1.00 hr @ $75.00/hr") == 1
     assert rendered.count("Programmer 1.00 hr @ $75.00/hr") == 0
     assert rendered.count("includes $200.00 extras") == 1
-    assert rendered.count("includes 1.67 hr extras") == 1
+    assert rendered.count("includes 1.67 hr extras") == 0
     assert rendered.count("1.50 hr @ $120.00/hr") == 1


### PR DESCRIPTION
## Summary
- adjust labor detail rendering to omit the redundant "includes X hr extras" message
- continue showing extra-hour pricing as standard hour lines when no base hours exist and otherwise summarize extras in dollars
- update mass display test to reflect the new output format

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py

------
https://chatgpt.com/codex/tasks/task_e_68e5af50dff08320b02bcdc50c46b940