### PR TITLE
Include programming hours in labor summary display

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5141,6 +5141,15 @@ def render_quote(
             hour_summary_entries.append((_process_label(key), hr_val))
             total_hours += hr_val if hr_val else 0.0
 
+    programming_meta = (nre_detail or {}).get("programming") or {}
+    try:
+        programming_hours = float(programming_meta.get("prog_hr", 0.0) or 0.0)
+    except Exception:
+        programming_hours = 0.0
+    if programming_hours > 0 or show_zeros:
+        hour_summary_entries.append(("Programming", programming_hours))
+        total_hours += programming_hours if programming_hours else 0.0
+
     if hour_summary_entries:
         lines.append("")
         lines.append("Labor Hour Summary")

--- a/tests/pricing/test_render_quote_ordering.py
+++ b/tests/pricing/test_render_quote_ordering.py
@@ -101,3 +101,46 @@ def test_render_quote_includes_hour_summary() -> None:
     assert any("Deburr" in line and "1.50 hr" in line for line in summary_block)
     assert any("Inspection" in line and "0.50 hr" in line for line in summary_block)
     assert any("Total Hours" in line and "6.00 hr" in line for line in summary_block)
+
+
+def test_render_quote_hour_summary_adds_programming_hours() -> None:
+    result = {
+        "price": 150.0,
+        "breakdown": {
+            "qty": 5,
+            "totals": {
+                "labor_cost": 90.0,
+                "direct_costs": 30.0,
+                "subtotal": 120.0,
+                "with_overhead": 132.0,
+                "with_ga": 138.6,
+                "with_contingency": 142.758,
+                "with_expedite": 142.758,
+            },
+            "nre_detail": {"programming": {"prog_hr": 2.0}},
+            "nre": {},
+            "material": {},
+            "process_costs": {"milling": 60.0},
+            "process_meta": {"milling": {"hr": 3.0}},
+            "pass_through": {"material": 30.0},
+            "applied_pcts": {
+                "OverheadPct": 0.10,
+                "GA_Pct": 0.05,
+                "ContingencyPct": 0.02,
+                "MarginPct": 0.15,
+            },
+            "rates": {},
+            "params": {},
+            "labor_cost_details": {},
+            "direct_cost_details": {},
+        },
+    }
+
+    rendered = appV5.render_quote(result, currency="$")
+    lines = rendered.splitlines()
+
+    assert "Labor Hour Summary" in lines
+    summary_idx = lines.index("Labor Hour Summary")
+    summary_block = lines[summary_idx:summary_idx + 6]
+    assert any("Programming" in line and "2.00 hr" in line for line in summary_block)
+    assert any("Total Hours" in line and "5.00 hr" in line for line in summary_block)


### PR DESCRIPTION
## Summary
- include programming hours from NRE details in the rendered labor hour summary
- add a regression test ensuring programming hours contribute to the total hours line

## Testing
- pytest tests/pricing/test_render_quote_ordering.py

------
https://chatgpt.com/codex/tasks/task_e_68e5afa140088320982b77f15a8be13a