### PR TITLE
Add divider lines before totals in rendered quotes

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -4855,7 +4855,24 @@ def render_quote(
         for segment in re.split(r";\s*", str(detail)):
             write_wrapped(segment, indent)
 
+    def _is_total_label(label: str) -> bool:
+        clean = str(label or "").strip()
+        if not clean:
+            return False
+        clean = clean.rstrip(":")
+        clean = clean.lstrip("= ")
+        return clean.lower().startswith("total")
+
+    def _ensure_total_separator():
+        if not lines:
+            return
+        if lines[-1] == divider:
+            return
+        lines.append(divider)
+
     def row(label: str, val: float, indent: str = ""):
+        if _is_total_label(label):
+            _ensure_total_separator()
         # left-label, right-amount aligned to page_width
         left = f"{indent}{label}"
         right = _m(val)
@@ -4863,6 +4880,8 @@ def render_quote(
         lines.append(f"{left}{' ' * pad}{right}")
 
     def hours_row(label: str, val: float, indent: str = ""):
+        if _is_total_label(label):
+            _ensure_total_separator()
         left = f"{indent}{label}"
         right = _h(val)
         pad = max(1, page_width - len(left) - len(right))

--- a/tests/pricing/test_render_quote_ordering.py
+++ b/tests/pricing/test_render_quote_ordering.py
@@ -43,6 +43,12 @@ def test_render_quote_places_why_after_pricing_ladder_and_llm_adjustments() -> N
     assert "LLM Adjustments" in lines
     assert "Why this price" in lines
 
+    total_labor_idx = next(i for i, line in enumerate(lines) if "Total Labor Cost" in line)
+    assert set(lines[total_labor_idx - 1]) == {"-"}
+
+    total_direct_idx = next(i for i, line in enumerate(lines) if "Total Direct Costs" in line)
+    assert set(lines[total_direct_idx - 1]) == {"-"}
+
     pricing_idx = lines.index("Pricing Ladder")
     llm_idx = lines.index("LLM Adjustments")
     why_idx = lines.index("Why this price")
@@ -96,8 +102,11 @@ def test_render_quote_includes_hour_summary() -> None:
     summary_idx = lines.index("Labor Hour Summary")
     divider_idx = summary_idx + 1
     assert lines[divider_idx].startswith("-")
-    summary_block = lines[summary_idx:summary_idx + 6]
+    summary_block = lines[summary_idx:summary_idx + 7]
     assert any("Milling" in line and "4.00 hr" in line for line in summary_block)
     assert any("Deburr" in line and "1.50 hr" in line for line in summary_block)
     assert any("Inspection" in line and "0.50 hr" in line for line in summary_block)
-    assert any("Total Hours" in line and "6.00 hr" in line for line in summary_block)
+
+    total_hours_idx = next(i for i, line in enumerate(lines) if "Total Hours" in line)
+    assert set(lines[total_hours_idx - 1]) == {"-"}
+    assert "6.00 hr" in lines[total_hours_idx]


### PR DESCRIPTION
## Summary
- insert automatic dividers before total rows in the rendered quote output
- update quote ordering tests to assert separators appear ahead of totals

## Testing
- pytest tests/pricing/test_render_quote_ordering.py

------
https://chatgpt.com/codex/tasks/task_e_68e5afbfa3988320b24133a288f876d7