### PR TITLE
Fix inspection total override propagation

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -2468,6 +2468,7 @@ def effective_to_overrides(effective: dict, baseline: dict | None = None) -> dic
         "cmm_minutes": (0.0, None),
         "in_process_inspection_hr": (0.0, None),
         "fai_prep_hr": (0.0, None),
+        "inspection_total_hr": (0.0, None),
         "packaging_hours": (0.0, None),
         "packaging_flat_cost": (0.0, None),
     }


### PR DESCRIPTION
## Summary
- add inspection_total_hr to the numeric override sanitization helper so inspection overrides persist

## Testing
- pytest tests/app/test_inspection_breakdown.py

------
https://chatgpt.com/codex/tasks/task_e_68e5b58aabf083209eb8e24d317ae329