### PR TITLE
Ensure extras-only processes still render detail and accumulate totals

### DIFF
--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -123,3 +123,7 @@ def test_render_quote_shows_flat_extras_when_no_hours() -> None:
 
     assert rendered.count("includes $200.00 extras") == 1
     assert "hr extras" not in rendered
+    process_total_line = next(
+        line for line in rendered.splitlines() if line.startswith("  Total")
+    )
+    assert process_total_line.strip().endswith("$200.00")


### PR DESCRIPTION
## Summary
- treat extras-only processes as displayable so detail/notes logic runs
- accumulate process totals using the numeric cost regardless of hours
- extend the flat-extras test to assert the process total reflects the extras amount

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py

------
https://chatgpt.com/codex/tasks/task_e_68e5b7ecedc08320ba7a4cb6d70cfebf