### PR TITLE
Adjust rendered quote total separators

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -4991,27 +4991,34 @@ def render_quote(
         clean = clean.lstrip("= ")
         return clean.lower().startswith("total")
 
-    def _ensure_total_separator():
+    def _ensure_total_separator(width: int) -> None:
         if not lines:
+            return
+        width = max(0, int(width))
+        if width <= 0:
             return
         if lines[-1] == divider:
             return
-        lines.append(divider)
+        pad = max(0, page_width - width)
+        short_divider = " " * pad + "-" * width
+        if lines[-1] == short_divider:
+            return
+        lines.append(short_divider)
 
     def row(label: str, val: float, indent: str = ""):
-        if _is_total_label(label):
-            _ensure_total_separator()
         # left-label, right-amount aligned to page_width
         left = f"{indent}{label}"
         right = _m(val)
+        if _is_total_label(label):
+            _ensure_total_separator(len(right))
         pad = max(1, page_width - len(left) - len(right))
         lines.append(f"{left}{' ' * pad}{right}")
 
     def hours_row(label: str, val: float, indent: str = ""):
-        if _is_total_label(label):
-            _ensure_total_separator()
         left = f"{indent}{label}"
         right = _h(val)
+        if _is_total_label(label):
+            _ensure_total_separator(len(right))
         pad = max(1, page_width - len(left) - len(right))
         lines.append(f"{left}{' ' * pad}{right}")
 

--- a/tests/pricing/test_render_quote_ordering.py
+++ b/tests/pricing/test_render_quote_ordering.py
@@ -44,10 +44,10 @@ def test_render_quote_places_why_after_pricing_ladder_and_llm_adjustments() -> N
     assert "Why this price" in lines
 
     total_labor_idx = next(i for i, line in enumerate(lines) if "Total Labor Cost" in line)
-    assert set(lines[total_labor_idx - 1]) == {"-"}
+    assert set(lines[total_labor_idx - 1].strip()) == {"-"}
 
     total_direct_idx = next(i for i, line in enumerate(lines) if "Total Direct Costs" in line)
-    assert set(lines[total_direct_idx - 1]) == {"-"}
+    assert set(lines[total_direct_idx - 1].strip()) == {"-"}
 
     pricing_idx = lines.index("Pricing Ladder")
     llm_idx = lines.index("LLM Adjustments")


### PR DESCRIPTION
## Summary
- update rendered quote formatting so total separators align with the numeric totals instead of spanning the full page width
- keep tests aligned with the new formatting behavior

## Testing
- pytest tests/pricing/test_render_quote_ordering.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c31e3514832098ff34a34a51b901