### PR TITLE
Move material weight details below stock summary

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5115,6 +5115,8 @@ def render_quote(
             ]
         )
 
+        detail_lines: list[str] = []
+
         if have_any:
             mat_lines.append("Material & Stock")
             mat_lines.append(divider)
@@ -5125,7 +5127,7 @@ def render_quote(
                     credit_display = f"-{credit_display}"
                 else:
                     credit_display = f"-{currency}{float(scrap_credit):,.2f}"
-                write_line(f"Scrap Credit: {credit_display}", "  ")
+                detail_lines.append(f"  Scrap Credit: {credit_display}")
             net_mass_val = _coerce_float_or_none(net_mass_g)
             effective_mass_val = _coerce_float_or_none(mass_g)
             if net_mass_val is None:
@@ -5152,14 +5154,18 @@ def render_quote(
                     )
 
             if (net_mass_val and net_mass_val > 0) or show_zeros:
-                write_line(f"Net Weight: {_format_weight_lb_oz(net_mass_val)}", "  ")
+                detail_lines.append(
+                    f"  Net Weight: {_format_weight_lb_oz(net_mass_val)}"
+                )
             if (
                 scrap
                 and effective_mass_val
                 and net_mass_val
                 and abs(float(effective_mass_val) - float(net_mass_val)) > 0.05
             ):
-                write_line(f"With Scrap: {_format_weight_lb_oz(effective_mass_val)}", "  ")
+                detail_lines.append(
+                    f"  With Scrap: {_format_weight_lb_oz(effective_mass_val)}"
+                )
 
             if upg or unit_price_kg or unit_price_lb or show_zeros:
                 grams_per_lb = 1000.0 / LB_PER_KG
@@ -5181,11 +5187,13 @@ def render_quote(
                     if price_asof:
                         extras.append(f"as of {price_asof}")
                     extra = f" ({', '.join(extras)})" if extras else ""
-                    write_line(f"Unit Price: {display_line}{extra}", "  ")
+                    detail_lines.append(f"  Unit Price: {display_line}{extra}")
             if price_source:
-                write_line(f"Source: {price_source}", "  ")
-            if minchg or show_zeros:  write_line(f"Supplier Min Charge: {_m(minchg or 0)}", "  ")
-            if scrap is not None:     write_line(f"Scrap %: {_pct(scrap)}", "  ")
+                detail_lines.append(f"  Source: {price_source}")
+            if minchg or show_zeros:
+                detail_lines.append(f"  Supplier Min Charge: {_m(minchg or 0)}")
+            if scrap is not None:
+                detail_lines.append(f"  Scrap %: {_pct(scrap)}")
             stock_L = _fmt_dim(ui_vars.get("Plate Length (in)"))
             stock_W = _fmt_dim(ui_vars.get("Plate Width (in)"))
             th_in = ui_vars.get("Thickness (in)")
@@ -5195,6 +5203,8 @@ def render_quote(
                 th_in = 1.0
             stock_T = _fmt_dim(th_in)
             mat_lines.append(f"  Stock used: {stock_L} × {stock_W} × {stock_T} in")
+            if detail_lines:
+                mat_lines.extend(detail_lines)
             mat_lines.append("")
 
     lines.extend(mat_lines)


### PR DESCRIPTION
## Summary
- collect material detail lines before rendering the section
- append scrap credit, weight, and pricing lines after the stock summary so they appear within the Material & Stock block

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c40f0de08320a94d7ea4c9c05840