### PR TITLE
Remove fixture material cost handling

### DIFF
--- a/Cad Files/cad_quote_full_coverage.py
+++ b/Cad Files/cad_quote_full_coverage.py
@@ -210,7 +210,7 @@ def compute_full_quote(xlsx_path: str,
         if re.search(r"Expected Scrap Rate", itm, flags=re.IGNORECASE):
             return ("meta", 0.0)
         # Material driven direct costs (BOM, fixture material, MOQ)
-        if re.search(r"Hardware|BOM|Fixture Material|Material MOQ", itm, flags=re.IGNORECASE):
+        if re.search(r"Hardware|BOM|Material MOQ", itm, flags=re.IGNORECASE):
             return ("material_cost", val)
         # Freight / shipping / lead time fees treated as logistics direct cost
         if re.search(r"Freight|Shipping|Lead Time", itm, flags=re.IGNORECASE):
@@ -565,7 +565,7 @@ def compute_full_quote(xlsx_path: str,
             if any(re.search(p, itm, flags=re.IGNORECASE) for p in pats):
                 return True
         # Or if it hit generic rules
-        if re.search(r"Profit Margin|Cost|Freight|MOQ|Material Vendor|Fixture Material|Tooling Cost|Lead Time|Hardware|BOM|Project Manager Hours|Tool & Die Maker|Precision Fitting|Number of Milling Setups|Number of Unique Tools|Number of Blanks Required|Labor|Time|Hours", itm, flags=re.IGNORECASE):
+        if re.search(r"Profit Margin|Cost|Freight|MOQ|Material Vendor|Tooling Cost|Lead Time|Hardware|BOM|Project Manager Hours|Tool & Die Maker|Precision Fitting|Number of Milling Setups|Number of Unique Tools|Number of Blanks Required|Labor|Time|Hours", itm, flags=re.IGNORECASE):
             return True
         return False
 

--- a/Cad Files/full_coverage_unused_numeric.csv
+++ b/Cad Files/full_coverage_unused_numeric.csv
@@ -31,7 +31,6 @@ GRD-04,Grinding Wheel Cost & Dressing Time,Cost of the abrasive wheel and the ti
 MIL-02,Number of Milling Setups,Each re-fixturing of the part adds significant labor.,0.5–2.0 hours labor per setup (+$50–$200).,Number,200
 TRN-09,Tooling Cost (Carbide Inserts),Cost of consumable turning inserts.,$20–$500 on tooling cost line item.,Number,225
 MAT-06,Material Vendor Lead Time,Long lead-time materials can delay the entire project.,Can add weeks to lead time; +$100s in expedite fees.,Number,250
-ENG-07,Fixture Material Cost,Cost of the raw materials for the fixture.,$100–$2000 in material NRE.,Number,350
 MIL-09,Tooling Cost (Carbide Endmills),Cost of consumable cutters, amortized over the job.,$50–$1000+ on tooling cost line item.,Number,450
 MAT-05,Material MOQ,If the job requires less than the MOQ, you must buy and store the excess.,Can increase material cost by 100-500% for small jobs.,Number,500
 ASM-01,Manual Assembly Labor,Time for installing hardware (helicoils, dowel pins, bearings).,$5–$150 per assembly.,Number,2000

--- a/Master_Variables.csv
+++ b/Master_Variables.csv
@@ -33,7 +33,6 @@ GRD-04,Grinding Wheel Cost & Dressing Time,Cost of the abrasive wheel and the ti
 MIL-02,Number of Milling Setups,Each re-fixturing of the part adds significant labor.,0.5–2.0 hours labor per setup (+$50–$200).,Number,200,,
 TRN-09,Tooling Cost (Carbide Inserts),Cost of consumable turning inserts.,$20–$500 on tooling cost line item.,Number,225,$,
 MAT-06,Material Vendor Lead Time,Long lead-time materials can delay the entire project.,Can add weeks to lead time; +$100s in expedite fees.,Number,250,,
-ENG-07,Fixture Material Cost,Cost of the raw materials for the fixture.,$100–$2000 in material NRE.,Number,350,$,
 MIL-09,Tooling Cost (Carbide Endmills),"Cost of consumable cutters, amortized over the job.",$50–$1000+ on tooling cost line item.,Number,450,$,
 MAT-05,Material MOQ,"If the job requires less than the MOQ, you must buy and store the excess.",Can increase material cost by 100-500% for small jobs.,Number,500,,
 ASM-01,Manual Assembly Labor,"Time for installing hardware (helicoils, dowel pins, bearings).",$5–$150 per assembly.,Number,2000,,

--- a/appV5.py
+++ b/appV5.py
@@ -372,7 +372,6 @@ def _auto_accept_suggestions(suggestions: dict[str, Any] | None) -> dict[str, An
         "setups",
         "fixture",
         "fixture_build_hr",
-        "fixture_material_cost",
         "soft_jaw_hr",
         "soft_jaw_material_cost",
         "handling_adder_hr",
@@ -1329,9 +1328,6 @@ def sanitize_suggestions(s: dict, bounds: dict) -> dict:
                 s[key] = setup_block.get(key)
         if "fixture_build_hr" in setup_block and "fixture_build_hr" not in s:
             s["fixture_build_hr"] = setup_block.get("fixture_build_hr")
-        if "fixture_material_cost" in setup_block and "fixture_material_cost" not in s:
-            s["fixture_material_cost"] = setup_block.get("fixture_material_cost")
-
     mults: dict[str, float] = {}
     for proc, raw_val in (s.get("process_hour_multipliers") or {}).items():
         value, detail = _extract_detail(raw_val)
@@ -1410,13 +1406,6 @@ def sanitize_suggestions(s: dict, bounds: dict) -> dict:
     fixture_build_hr = _extract_float_field(fixture_build_raw, 0.0, 2.0, ("fixture_build_hr",))
     if fixture_build_hr is not None:
         extra["fixture_build_hr"] = fixture_build_hr
-
-    fixture_material_raw = s.get("fixture_material_cost")
-    if fixture_material_raw is None and setup_block:
-        fixture_material_raw = setup_block.get("fixture_material_cost")
-    fixture_material_cost = _extract_float_field(fixture_material_raw, 0.0, 250.0, ("fixture_material_cost",))
-    if fixture_material_cost is not None:
-        extra["fixture_material_cost"] = fixture_material_cost
 
     soft_block = s.get("soft_jaw_plan") if isinstance(s.get("soft_jaw_plan"), dict) else None
     soft_hr_raw = s.get("soft_jaw_hr")
@@ -1716,8 +1705,6 @@ def overrides_to_suggestions(overrides: dict | None) -> dict:
         suggestions["add_pass_through"] = dict(overrides["add_pass_through"])
     if overrides.get("scrap_pct_override") is not None:
         suggestions["scrap_pct"] = overrides.get("scrap_pct_override")
-    if overrides.get("fixture_material_cost_delta") is not None:
-        suggestions["fixture_material_cost_delta"] = overrides.get("fixture_material_cost_delta")
     if overrides.get("contingency_pct_override") is not None:
         suggestions["contingency_pct"] = overrides.get("contingency_pct_override")
     setup_plan = overrides.get("setup_recommendation")
@@ -1734,7 +1721,6 @@ def overrides_to_suggestions(overrides: dict | None) -> dict:
         suggestions["notes"] = list(overrides["notes"])
     for key in (
         "fixture_build_hr",
-        "fixture_material_cost",
         "soft_jaw_hr",
         "soft_jaw_material_cost",
         "handling_adder_hr",
@@ -1769,8 +1755,6 @@ def suggestions_to_overrides(suggestions: dict | None) -> dict:
         out["add_pass_through"] = dict(apt)
     if suggestions.get("scrap_pct") is not None:
         out["scrap_pct_override"] = suggestions.get("scrap_pct")
-    if suggestions.get("fixture_material_cost_delta") is not None:
-        out["fixture_material_cost_delta"] = suggestions.get("fixture_material_cost_delta")
     if suggestions.get("contingency_pct") is not None:
         out["contingency_pct_override"] = suggestions.get("contingency_pct")
     setups = suggestions.get("setups")
@@ -1785,7 +1769,6 @@ def suggestions_to_overrides(suggestions: dict | None) -> dict:
         out["notes"] = list(suggestions["notes"])
     for key in (
         "fixture_build_hr",
-        "fixture_material_cost",
         "soft_jaw_hr",
         "soft_jaw_material_cost",
         "handling_adder_hr",
@@ -2090,24 +2073,6 @@ def merge_effective(
     eff["scrap_pct"] = float(scrap_val)
     source_tags["scrap_pct"] = scrap_source
 
-    fixture_delta_user = overrides.get("fixture_material_cost_delta")
-    fixture_delta_sugg = suggestions.get("fixture_material_cost_delta")
-    fixture_delta_source = "baseline"
-    fixture_delta_val = None
-    if fixture_delta_user is not None:
-        cand = _as_float_or_none(fixture_delta_user)
-        if cand is not None:
-            fixture_delta_val = float(cand)
-            fixture_delta_source = "user"
-    elif fixture_delta_sugg is not None:
-        cand = _as_float_or_none(fixture_delta_sugg)
-        if cand is not None:
-            fixture_delta_val = float(cand)
-            fixture_delta_source = "llm"
-    if fixture_delta_val is not None:
-        eff["fixture_material_cost_delta"] = fixture_delta_val
-    source_tags["fixture_material_cost_delta"] = fixture_delta_source
-
     contingency_base = baseline.get("contingency_pct")
     contingency_user = overrides.get("contingency_pct") or overrides.get("contingency_pct_override")
     contingency_sugg = suggestions.get("contingency_pct")
@@ -2171,7 +2136,6 @@ def merge_effective(
         eff["notes"] = notes_val
 
     _merge_numeric_field("fixture_build_hr", 0.0, 2.0, "fixture_build_hr")
-    _merge_numeric_field("fixture_material_cost", 0.0, 250.0, "fixture_material_cost")
     _merge_numeric_field("soft_jaw_hr", 0.0, 1.0, "soft_jaw_hr")
     _merge_numeric_field("soft_jaw_material_cost", 0.0, 60.0, "soft_jaw_material_cost")
     _merge_numeric_field("handling_adder_hr", 0.0, 0.2, "handling_adder_hr")
@@ -2307,7 +2271,6 @@ def compute_effective_state(state: QuoteState) -> tuple[dict, dict]:
         "setups",
         "fixture",
         "fixture_build_hr",
-        "fixture_material_cost",
         "soft_jaw_hr",
         "soft_jaw_material_cost",
         "handling_adder_hr",
@@ -2511,9 +2474,6 @@ def effective_to_overrides(effective: dict, baseline: dict | None = None) -> dic
     scrap_base = baseline.get("scrap_pct")
     if scrap_eff is not None and (scrap_base is None or not math.isclose(float(scrap_eff), float(scrap_base or 0.0), abs_tol=1e-6)):
         out["scrap_pct_override"] = float(scrap_eff)
-    fixture_delta = effective.get("fixture_material_cost_delta")
-    if fixture_delta is not None and not math.isclose(float(fixture_delta), 0.0, abs_tol=1e-6):
-        out["fixture_material_cost_delta"] = float(fixture_delta)
     contingency_eff = effective.get("contingency_pct")
     contingency_base = baseline.get("contingency_pct")
     if contingency_eff is not None and (contingency_base is None or not math.isclose(float(contingency_eff), float(contingency_base or 0.0), abs_tol=1e-6)):
@@ -2528,7 +2488,6 @@ def effective_to_overrides(effective: dict, baseline: dict | None = None) -> dic
             out["setup_recommendation"]["fixture"] = fixture_eff
     numeric_keys = {
         "fixture_build_hr": (0.0, None),
-        "fixture_material_cost": (0.0, None),
         "soft_jaw_hr": (0.0, None),
         "soft_jaw_material_cost": (0.0, None),
         "handling_adder_hr": (0.0, None),
@@ -2590,12 +2549,10 @@ def ensure_accept_flags(state: QuoteState) -> None:
 
     for key in (
         "scrap_pct",
-        "fixture_material_cost_delta",
         "contingency_pct",
         "setups",
         "fixture",
         "fixture_build_hr",
-        "fixture_material_cost",
         "soft_jaw_hr",
         "soft_jaw_material_cost",
         "handling_adder_hr",
@@ -2733,23 +2690,6 @@ def iter_suggestion_rows(state: QuoteState) -> list[dict]:
             "source": cont_src,
         })
 
-    fixture_delta_llm = suggestions.get("fixture_material_cost_delta")
-    fixture_delta_user = overrides.get("fixture_material_cost_delta")
-    fixture_delta_eff = effective.get("fixture_material_cost_delta")
-    fixture_delta_src = sources.get("fixture_material_cost_delta", "baseline")
-    if any(v is not None for v in (fixture_delta_llm, fixture_delta_user, fixture_delta_eff)):
-        rows.append({
-            "path": ("fixture_material_cost_delta",),
-            "label": "Fixture material Δ",
-            "kind": "currency",
-            "baseline": 0.0,
-            "llm": fixture_delta_llm,
-            "user": fixture_delta_user,
-            "accept": bool(accept.get("fixture_material_cost_delta")),
-            "effective": fixture_delta_eff or 0.0,
-            "source": fixture_delta_src,
-        })
-
     setups_base = baseline.get("setups")
     setups_llm = suggestions.get("setups")
     setups_user = overrides.get("setups")
@@ -2809,7 +2749,6 @@ def iter_suggestion_rows(state: QuoteState) -> list[dict]:
         )
 
     _add_scalar_row(("fixture_build_hr",), "Fixture Build Hours", "hours", "fixture_build_hr")
-    _add_scalar_row(("fixture_material_cost",), "Fixture Material $", "currency", "fixture_material_cost")
     _add_scalar_row(("soft_jaw_hr",), "Soft Jaw Hours", "hours", "soft_jaw_hr")
     _add_scalar_row(("soft_jaw_material_cost",), "Soft Jaw Material $", "currency", "soft_jaw_material_cost")
     _add_scalar_row(("handling_adder_hr",), "Handling Adder Hours", "hours", "handling_adder_hr")
@@ -5219,15 +5158,12 @@ def render_quote(
             write_detail(nre_cost_details.get("Programming & Eng (per lot)"))
 
     # Fixturing (with renamed subline)
-    if (fix.get("per_lot", 0.0) > 0) or show_zeros or any(fix.get(k) for k in ("build_hr", "mat_cost")):
+    if (fix.get("per_lot", 0.0) > 0) or show_zeros or fix.get("build_hr"):
         row("Fixturing:", float(fix.get("per_lot", 0.0)))
         has_detail = False
         if fix.get("build_hr"):
             has_detail = True
             write_line(f"- Build Labor: {_h(fix['build_hr'])} @ {_m(fix.get('build_rate', 0))}/hr", "    ")
-        if fix.get("mat_cost"):
-            has_detail = True
-            write_line(f"- Fixture Material Cost: {_m(fix.get('mat_cost', 0.0))}", "    ")
         if not has_detail:
             write_detail(nre_cost_details.get("Fixturing (per lot)"))
 
@@ -6928,8 +6864,12 @@ def compute_quote_from_df(df: pd.DataFrame,
 
     if hole_scrap_frac_est and hole_scrap_frac_est > 0:
         hole_scrap_clamped_val = max(0.0, min(0.25, float(hole_scrap_frac_est)))
-        scrap_pct = max(scrap_pct, hole_scrap_clamped_val)
-        scrap_pct_baseline = max(scrap_pct_baseline, hole_scrap_clamped_val)
+        if scrap_source_label == "default_guess":
+            scrap_pct = hole_scrap_clamped_val
+            scrap_pct_baseline = hole_scrap_clamped_val
+        else:
+            scrap_pct = max(scrap_pct, hole_scrap_clamped_val)
+            scrap_pct_baseline = max(scrap_pct_baseline, hole_scrap_clamped_val)
         geo_context.setdefault("scrap_pct_from_holes", float(hole_scrap_frac_est))
         geo_context.setdefault("scrap_pct_from_holes_clamped", hole_scrap_clamped_val)
         if inner_geo is not None:
@@ -7210,11 +7150,9 @@ def compute_quote_from_df(df: pd.DataFrame,
 
     # ---- fixture -------------------------------------------------------------
     fixture_build_hr = sum_time(r"(?:Fixture\s*Build|Custom\s*Fixture\s*Build)")
-    fixture_mat_cost = num(r"(?:Fixture\s*Material\s*Cost|Fixture\s*Hardware)")
-    # Explicit fields for clarity downstream
-    fixture_material_cost = float(fixture_mat_cost)
+    # Fixture material cost is no longer applied; only labor is considered.
     fixture_labor_cost    = float(fixture_build_hr) * float(rates["FixtureBuildRate"])
-    fixture_cost          = fixture_labor_cost + fixture_material_cost
+    fixture_cost          = fixture_labor_cost
     fixture_labor_per_part = (fixture_labor_cost / Qty) if Qty > 1 else fixture_labor_cost
     fixture_per_part       = (fixture_cost / Qty) if Qty > 1 else fixture_cost
 
@@ -7233,7 +7171,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         "fixture": {
             "build_hr": float(fixture_build_hr), "build_rate": rates["FixtureBuildRate"],
             "labor_cost": float(fixture_labor_cost),
-            "mat_cost": float(fixture_material_cost),
             "per_lot": fixture_cost, "per_part": fixture_per_part
         }
     }
@@ -7595,7 +7532,6 @@ def compute_quote_from_df(df: pd.DataFrame,
 
     pass_meta = {
         "Material": {"basis": "Stock / raw material"},
-        "Fixture Material": {"basis": "Fixture raw stock"},
         "Hardware / BOM": {"basis": "Pass-through hardware / BOM"},
         "Outsourced Vendors": {"basis": "Outside processing vendors"},
         "Shipping": {"basis": "Freight & logistics"},
@@ -7618,7 +7554,6 @@ def compute_quote_from_df(df: pd.DataFrame,
 
     pass_through = {
         "Material": material_direct_cost,
-        "Fixture Material": fixture_material_cost,
         "Hardware / BOM": hardware_cost,
         "Outsourced Vendors": outsourced_costs,
         "Shipping": shipping_cost,
@@ -7637,17 +7572,8 @@ def compute_quote_from_df(df: pd.DataFrame,
         fb = float(fixture_build_hr)
     except Exception:
         fb = 0.0
-    try:
-        fm = float(fixture_material_cost)
-    except Exception:
-        fm = 0.0
-    if fb or fm:
-        pieces: list[str] = []
-        if fb:
-            pieces.append(f"{fb:.2f} hr build")
-        if fm:
-            pieces.append(f"${fm:,.2f} material")
-        fixture_plan_desc = ", ".join(pieces)
+    if fb:
+        fixture_plan_desc = f"{fb:.2f} hr build"
     strategy = fix_detail.get("strategy") if isinstance(fix_detail, dict) else None
     if isinstance(strategy, str) and strategy.strip():
         if fixture_plan_desc:
@@ -7753,7 +7679,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         "part_mass_g_est": part_mass_g_est,
         "dfm_geo": dfm_geo,
         "fixture_build_hr": float(fixture_build_hr or 0.0),
-        "fixture_material_cost": float(fixture_material_cost),
         "cmm_minutes": float((cmm_run_hr or 0.0) * 60.0),
         "in_process_inspection_hr": float(inproc_hr or 0.0),
         "packaging_hours": float(packaging_hr or 0.0),
@@ -8334,7 +8259,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         "setups": int(setups),
         "contingency_pct": ContingencyPct,
         "fixture_build_hr": fixture_build_hr_base,
-        "fixture_material_cost": float(fixture_material_cost),
         "soft_jaw_hr": 0.0,
         "soft_jaw_material_cost": 0.0,
         "handling_adder_hr": 0.0,
@@ -9040,7 +8964,6 @@ def compute_quote_from_df(df: pd.DataFrame,
     fixture_build_override = _clamp_override((overrides or {}).get("fixture_build_hr"), 0.0, 2.0)
     soft_jaw_hr_override = _clamp_override((overrides or {}).get("soft_jaw_hr"), 0.0, 1.0) or 0.0
     soft_jaw_cost_override = _clamp_override((overrides or {}).get("soft_jaw_material_cost"), 0.0, 60.0) or 0.0
-    fixture_material_override = _clamp_override((overrides or {}).get("fixture_material_cost"), 0.0, 250.0)
 
     total_fixture_hr = fixture_build_override if fixture_build_override is not None else fixture_build_hr_base
     if soft_jaw_hr_override > 0:
@@ -9049,19 +8972,13 @@ def compute_quote_from_df(df: pd.DataFrame,
     if fixture_build_override is not None:
         fixture_notes.append(f"Fixture build set to {fixture_build_override:.2f} h{_source_suffix('fixture_build_hr')}")
 
-    fixture_material_updated = fixture_material_cost
-    if fixture_material_override is not None:
-        fixture_material_updated = fixture_material_override
-        fixture_notes.append(f"Fixture material set to ${fixture_material_override:,.2f}{_source_suffix('fixture_material_cost')}")
     if soft_jaw_cost_override > 0:
-        fixture_material_updated += soft_jaw_cost_override
         fixture_notes.append(f"Soft jaw stock +${soft_jaw_cost_override:,.2f}{_source_suffix('soft_jaw_material_cost')}")
 
-    if total_fixture_hr != fixture_build_hr_base or fixture_material_updated != fixture_material_cost:
+    if total_fixture_hr != fixture_build_hr_base or soft_jaw_cost_override > 0:
         fixture_build_hr = total_fixture_hr
-        fixture_material_cost = fixture_material_updated
         fixture_labor_cost = fixture_build_hr * float(rates.get("FixtureBuildRate", 0.0))
-        fixture_cost = fixture_labor_cost + fixture_material_cost
+        fixture_cost = fixture_labor_cost
         fixture_labor_per_part = (fixture_labor_cost / Qty) if Qty > 1 else fixture_labor_cost
         fixture_per_part = (fixture_cost / Qty) if Qty > 1 else fixture_cost
         nre_detail.setdefault("fixture", {})
@@ -9069,17 +8986,13 @@ def compute_quote_from_df(df: pd.DataFrame,
             {
                 "build_hr": float(fixture_build_hr),
                 "labor_cost": float(fixture_labor_cost),
-                "mat_cost": float(fixture_material_cost),
                 "per_lot": float(fixture_cost),
                 "per_part": float(fixture_per_part),
                 "soft_jaw_hr": float(soft_jaw_hr_override),
                 "soft_jaw_mat": float(soft_jaw_cost_override),
             }
         )
-        pass_through["Fixture Material"] = float(fixture_material_cost)
-        fixture_material_cost_base = float(fixture_material_cost)
         features["fixture_build_hr"] = float(fixture_build_hr)
-        features["fixture_material_cost"] = float(fixture_material_cost)
 
     handling_override = _clamp_override((overrides or {}).get("handling_adder_hr"), 0.0, 0.2)
     if handling_override and handling_override > 0:
@@ -9171,7 +9084,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         llm_notes.extend(fixture_notes)
 
     material_direct_cost_base = material_direct_cost
-    fixture_material_cost_base = fixture_material_cost
 
     old_scrap = _ensure_scrap_pct(features.get("scrap_pct", scrap_pct))
     base_net_mass_g = _coerce_float_or_none(material_detail_for_breakdown.get("net_mass_g")) or 0.0
@@ -9408,28 +9320,6 @@ def compute_quote_from_df(df: pd.DataFrame,
             suffix = " (LLM)"
         llm_notes.append(f"{actual_label}: +${float(add_val):,.0f}{suffix}")
 
-    delta_fix_mat = overrides.get("fixture_material_cost_delta") if overrides else None
-    if isinstance(delta_fix_mat, (int, float)) and delta_fix_mat:
-        delta_fix_mat = clamp(delta_fix_mat, -200.0, 200.0, 0.0)
-        if delta_fix_mat:
-            old_val = float(pass_through.get("Fixture Material", fixture_material_cost_base))
-            new_val = round(old_val + float(delta_fix_mat), 2)
-            pass_through["Fixture Material"] = new_val
-            pass_key_map[_normalize_key("Fixture Material")] = "Fixture Material"
-            entry = applied_pass.setdefault("Fixture Material", {"old_value": old_val, "notes": []})
-            entry["notes"].append(f"Δ${float(delta_fix_mat):+.2f}")
-            entry["new_value"] = new_val
-            fix_detail["mat_cost"] = round(float(fix_detail.get("mat_cost", 0.0)) + float(delta_fix_mat), 2)
-            src_tag = None
-            if isinstance(quote_state.effective_sources, dict):
-                src_tag = quote_state.effective_sources.get("fixture_material_cost_delta")
-            suffix = ""
-            if src_tag == "user":
-                suffix = " (user override)"
-            elif src_tag == "llm":
-                suffix = " (LLM)"
-            llm_notes.append(f"Fixture material ${float(delta_fix_mat):+.0f}{suffix}")
-
     cont_override = overrides.get("contingency_pct_override") if overrides else None
     if cont_override is not None:
         cont_val = clamp(cont_override, 0.0, 0.25, ContingencyPct)
@@ -9514,7 +9404,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         entry["delta_value"] = entry["new_value"] - entry["old_value"]
 
     material_direct_cost = float(pass_through.get("Material", material_direct_cost_base))
-    fixture_material_cost = float(pass_through.get("Fixture Material", fixture_material_cost_base))
     hardware_cost = float(pass_through.get("Hardware / BOM", hardware_cost))
     outsourced_costs = float(pass_through.get("Outsourced Vendors", outsourced_costs))
     shipping_cost = float(pass_through.get("Shipping", shipping_cost))
@@ -9646,8 +9535,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         details = []
         if fix_detail.get("build_hr"):
             details.append(f"Build {fix_detail['build_hr']:.2f} hr @ ${fix_detail.get('build_rate',0):,.2f}/hr")
-        if fixture_material_cost:
-            details.append(f"Material ${fixture_material_cost:,.2f}")
         if details:
             nre_cost_details[label] = "; ".join(details)
 
@@ -9701,7 +9588,6 @@ def compute_quote_from_df(df: pd.DataFrame,
     breakdown = {
         "qty": Qty,
         "scrap_pct": scrap_pct,
-        "fixture_material_cost": fixture_material_cost,
         "material_direct_cost": material_direct_cost,
         "total_direct_costs": round(total_direct_costs, 2),
         "material": material_detail_for_breakdown,
@@ -13059,7 +12945,6 @@ def get_llm_overrides(
         "process_hour_multipliers": {"milling": 1.10, "turning": 0.95, ...},
         "process_hour_adders": {"milling": 0.25, "inspection": 0.10},   # hours
         "add_pass_through": {"Material": 12.0, "Tooling": 30.0},        # dollars
-        "fixture_material_cost_delta": 0.0,       # dollars (+/-)
         "contingency_pct_override": 0.00-0.25,    # optional
         "notes": ["short human-readable bullets"]
       }
@@ -13473,16 +13358,6 @@ def get_llm_overrides(
             clamp_notes.append(f"add_pass_through[{k}] non-numeric")
     if clean_pass:
         out["add_pass_through"] = clean_pass
-
-    fmd = parsed.get("fixture_material_cost_delta", None)
-    if isinstance(fmd, (int, float)):
-        orig = float(fmd)
-        clamped_val = clamp(fmd, -200.0, 200.0, 0.0)
-        out["fixture_material_cost_delta"] = clamped_val
-        if not math.isclose(orig, clamped_val, abs_tol=1e-6):
-            clamp_notes.append(
-                f"fixture_material_cost_delta {orig:.2f} → {clamped_val:.2f}"
-            )
 
     cont = parsed.get("contingency_pct_override", None)
     if cont is not None:

--- a/cad_quoter/llm.py
+++ b/cad_quoter/llm.py
@@ -122,11 +122,6 @@ SUGG_TO_EDITOR = {
         float,
         float,
     ),
-    "fixture_material_cost_delta": (
-        "Fixture Material Cost",
-        float,
-        float,
-    ),
 }
 
 EDITOR_TO_SUGG = {spec[0]: key for key, spec in SUGG_TO_EDITOR.items()}
@@ -802,7 +797,7 @@ def _estimator_patterns():
         r"(Programming|CAM\s*Programming|2D\s*CAM|3D\s*CAM|Simulation|Verification|DFM\s*Review|Tool\s*Library|Setup\s*Sheets)",
         r"\b(CAM\s*Programming|CAM\s*Sim|Post\s*Processing)\b",
         r"(Fixture\s*Design|Process\s*Sheet|Traveler|Documentation|Complex\s*Assembly\s*Doc)",
-        r"(Fixture\s*Build|Custom\s*Fixture\s*Build)", r"(Fixture\s*Material\s*Cost|Fixture\s*Hardware)",
+        r"(Fixture\s*Build|Custom\s*Fixture\s*Build)",
         r"(Roughing\s*Cycle\s*Time|Adaptive|HSM)", r"(Semi[- ]?Finish|Rest\s*Milling)", r"(Finishing\s*Cycle\s*Time)",
         r"(Number\s*of\s*Milling\s*Setups|Milling\s*Setups)", r"(Setup\s*Time\s*per\s*Setup|Setup\s*Hours\s*/\s*Setup)",
         r"(Thin\s*Wall\s*Factor|Thin\s*Wall\s*Multiplier)", r"(Tolerance\s*Multiplier|Tight\s*Tolerance\s*Factor)",

--- a/tests/domain/test_effective_state.py
+++ b/tests/domain/test_effective_state.py
@@ -89,7 +89,6 @@ def test_reprice_with_effective_applies_drilling_floor() -> None:
 def test_merge_effective_tracks_new_fields() -> None:
     baseline = {
         "fixture_build_hr": 0.5,
-        "fixture_material_cost": 40.0,
         "_bounds": {"scrap_max": 0.25},
     }
     suggestions = {


### PR DESCRIPTION
## Summary
- remove fixture material cost tracking and related overrides from the quoting flow and price breakdowns
- adjust scrap estimation to favor geometry-derived removal fractions when only default scrap is available
- drop fixture material cost references from LLM mappings, regression fixtures, and configuration CSVs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5c4903edc83208123ff700ce498ce