### PR TITLE
Convert flat process extras to equivalent hours in quote rendering

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5267,7 +5267,13 @@ def render_quote(
             if hr_val > 0:
                 detail_bits.append(f"{hr_val:.2f} hr @ ${rate_val:,.2f}/hr")
             if abs(extra_val) > 1e-6:
-                detail_bits.append(f"includes ${extra_val:,.2f} extras")
+                if hr_val <= 1e-6 and rate_val > 0:
+                    extra_hours = extra_val / rate_val
+                    detail_bits.append(
+                        f"{extra_hours:.2f} hr @ ${rate_val:,.2f}/hr"
+                    )
+                else:
+                    detail_bits.append(f"includes ${extra_val:,.2f} extras")
             proc_notes = applied_process.get(str(key).lower(), {}).get("notes")
             if proc_notes:
                 detail_bits.append("LLM: " + ", ".join(proc_notes))

--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -178,5 +178,5 @@ def test_render_quote_shows_flat_extras_when_no_hours() -> None:
 
     rendered = appV5.render_quote(result, currency="$", show_zeros=False)
 
-    assert rendered.count("includes $200.00 extras") == 1
-    assert "hr extras" not in rendered
+    assert "includes $200.00 extras" not in rendered
+    assert rendered.count("2.22 hr @ $90.00/hr") == 1


### PR DESCRIPTION
## Summary
- convert process extras into equivalent labor hours when no hours are reported, so flat extras show as rate-based time
- update the mass display rendering test to validate the new format

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c4e53a1c83208144cabbdfcdbba4