### PR TITLE
Default shipping to 15% of material with override support

### DIFF
--- a/cad_quoter/llm.py
+++ b/cad_quoter/llm.py
@@ -93,6 +93,11 @@ SUGG_TO_EDITOR = {
         float,
         float,
     ),
+    "shipping_cost": (
+        "Shipping Cost Override",
+        float,
+        float,
+    ),
     "fai_required": (
         "FAIR Required",
         lambda flag: 1 if flag else 0,

--- a/tests/domain/test_effective_state.py
+++ b/tests/domain/test_effective_state.py
@@ -90,21 +90,24 @@ def test_merge_effective_tracks_new_fields() -> None:
     baseline = {
         "fixture_build_hr": 0.5,
         "fixture_material_cost": 40.0,
+        "shipping_cost": 25.0,
         "_bounds": {"scrap_max": 0.25},
     }
     suggestions = {
         "fixture_build_hr": 1.2,
         "soft_jaw_hr": 0.3,
         "packaging_flat_cost": 12.0,
+        "shipping_cost": 30.0,
         "shipping_hint": "Foam inserts",
     }
-    overrides = {"fai_required": True}
+    overrides = {"fai_required": True, "shipping_cost": 20.0}
 
     merged = merge_effective(baseline, suggestions, overrides)
 
     assert merged["fixture_build_hr"] == pytest.approx(1.2)
     assert merged["soft_jaw_hr"] == pytest.approx(0.3)
     assert merged["packaging_flat_cost"] == pytest.approx(12.0)
+    assert merged["shipping_cost"] == pytest.approx(20.0)
     assert merged["fai_required"] is True
     assert merged["shipping_hint"] == "Foam inserts"
 
@@ -115,6 +118,7 @@ def test_effective_to_overrides_emits_new_keys() -> None:
         "soft_jaw_hr": 0.25,
         "cmm_minutes": 18.0,
         "packaging_hours": 0.2,
+        "shipping_cost": 18.0,
         "shipping_hint": "Double box",
     }
     overrides = effective_to_overrides(effective, {})
@@ -123,4 +127,5 @@ def test_effective_to_overrides_emits_new_keys() -> None:
     assert overrides["soft_jaw_hr"] == pytest.approx(0.25)
     assert overrides["cmm_minutes"] == pytest.approx(18.0)
     assert overrides["packaging_hours"] == pytest.approx(0.2)
+    assert overrides["shipping_cost"] == pytest.approx(18.0)
     assert overrides["shipping_hint"] == "Double box"


### PR DESCRIPTION
## Summary
- compute the baseline shipping cost from 15% of the material spend and carry the basis through pass-through metadata
- add explicit shipping cost overrides to the effective-state merge, UI rows, and pricing application so user values replace the default
- expose the new shipping field to the LLM mapping and extend unit tests to cover merge and override behaviour

## Testing
- pytest tests/domain/test_effective_state.py

------
https://chatgpt.com/codex/tasks/task_e_68e5c5632100832093bd4d26eb5d8960