### PR TITLE
Rename hardware pass-through label

### DIFF
--- a/Cad Files/full_coverage_unused_numeric.csv
+++ b/Cad Files/full_coverage_unused_numeric.csv
@@ -24,7 +24,7 @@ QC-01,In-Process Inspection Labor,Operator time spent checking parts at the mach
 ENG-06,Fixture Build Labor Hours,Toolmaker time to assemble and qualify the custom fixture.,4–40 hours of toolmaker time (+$300–$3000).,Number,12
 PM-08,Project Manager Hours,Complex projects with many milestones require dedicated management time.,$500–$5000+ for dedicated project management.,Number,20
 COM-07,Profit Margin,The percentage added to the total cost to arrive at the final price.,15–40% of total cost.,Number,35
-ASM-02,Hardware / BOM Cost,The purchase cost of all fasteners and components to be installed.,Direct cost input.,Number,75.5
+ASM-02,Hardware Cost,The purchase cost of all fasteners and components to be installed.,Direct cost input.,Number,75.5
 MAT-09,Number of Blanks Required,Total pieces of raw stock needed for the job.,Direct cost multiplier.,Number,102
 COM-03,Freight / Shipping Cost,The direct cost charged by the carrier.,Direct cost input.,Number,125
 GRD-04,Grinding Wheel Cost & Dressing Time,Cost of the abrasive wheel and the time spent preparing it.,$100–$500 NRE; +0.1 hr labor per part.,Number,200

--- a/Master_Variables.csv
+++ b/Master_Variables.csv
@@ -24,7 +24,7 @@ QC-01,In-Process Inspection Labor,Operator time spent checking parts at the mach
 ENG-06,Fixture Build Labor Hours,Toolmaker time to assemble and qualify the custom fixture.,4–40 hours of toolmaker time (+$300–$3000).,Number,12,hr,
 PM-08,Project Manager Hours,Complex projects with many milestones require dedicated management time.,$500–$5000+ for dedicated project management.,Number,20,hr,
 COM-07,Profit Margin,The percentage added to the total cost to arrive at the final price.,15–40% of total cost.,Number,35,,
-ASM-02,Hardware / BOM Cost,The purchase cost of all fasteners and components to be installed.,Direct cost input.,Number,75.5,$,
+ASM-02,Hardware Cost,The purchase cost of all fasteners and components to be installed.,Direct cost input.,Number,75.5,$,
 GRD-01,Surface Grinder Rate,Hourly cost for precision surface grinding.,$70–$90 per hour.,Lookup – Rate,$80.00,$/hr,GRD_01
 GRD-02,OD/ID Grinder Rate,Hourly cost for cylindrical grinding.,$80–$120 per hour.,Lookup – Rate,$100.00,$/hr,GRD_02
 MAT-09,Number of Blanks Required,Total pieces of raw stock needed for the job.,Direct cost multiplier.,Number,102,,

--- a/appV5.py
+++ b/appV5.py
@@ -185,6 +185,22 @@ PROC_MULT_TARGETS: dict[str, tuple[str, float]] = {
     "packaging": ("Packaging Labor Hours", 1.0),
 }
 
+HARDWARE_PASS_LABEL = "Hardware"
+LEGACY_HARDWARE_PASS_LABEL = "Hardware / BOM"
+_HARDWARE_LABEL_ALIASES = {
+    HARDWARE_PASS_LABEL.lower(),
+    LEGACY_HARDWARE_PASS_LABEL.lower(),
+    "hardware/bom",
+    "hardware bom",
+}
+
+
+def _canonical_pass_label(label: str | None) -> str:
+    name = str(label or "").strip()
+    if name.lower() in _HARDWARE_LABEL_ALIASES:
+        return HARDWARE_PASS_LABEL
+    return name
+
 from OCP.TopAbs   import TopAbs_EDGE, TopAbs_FACE
 from OCP.TopExp   import TopExp, TopExp_Explorer
 from OCP.TopTools import TopTools_IndexedDataMapOfShapeListOfShape
@@ -1028,7 +1044,8 @@ def build_suggest_payload(
     for label, amount in (baseline_pass_raw or {}).items():
         val = _coerce_float(amount)
         if val is not None:
-            baseline_pass[str(label)] = float(val)
+            canon_label = _canonical_pass_label(label)
+            baseline_pass[canon_label] = float(val)
 
     top_process_hours = sorted(baseline_hours.items(), key=lambda kv: (-kv[1], kv[0]))[:6]
     top_pass_through = sorted(baseline_pass.items(), key=lambda kv: (-kv[1], kv[0]))[:6]
@@ -7596,7 +7613,7 @@ def compute_quote_from_df(df: pd.DataFrame,
     pass_meta = {
         "Material": {"basis": "Stock / raw material"},
         "Fixture Material": {"basis": "Fixture raw stock"},
-        "Hardware / BOM": {"basis": "Pass-through hardware / BOM"},
+        HARDWARE_PASS_LABEL: {"basis": "Pass-through hardware & BOM"},
         "Outsourced Vendors": {"basis": "Outside processing vendors"},
         "Shipping": {"basis": "Freight & logistics"},
         "Consumables /Hr": {"basis": "Machine & inspection hours $/hr"},
@@ -7619,13 +7636,17 @@ def compute_quote_from_df(df: pd.DataFrame,
     pass_through = {
         "Material": material_direct_cost,
         "Fixture Material": fixture_material_cost,
-        "Hardware / BOM": hardware_cost,
+        HARDWARE_PASS_LABEL: hardware_cost,
         "Outsourced Vendors": outsourced_costs,
         "Shipping": shipping_cost,
         "Consumables /Hr": consumables_hr_cost,
         "Utilities": utilities_cost,
         "Consumables Flat": consumables_flat,
         "Packaging Flat": packaging_flat_base,
+    }
+    pass_through = {
+        _canonical_pass_label(label): float(value)
+        for label, value in pass_through.items()
     }
     if material_scrap_credit_applied:
         pass_through["Material Scrap Credit"] = -material_scrap_credit_applied
@@ -9026,7 +9047,11 @@ def compute_quote_from_df(df: pd.DataFrame,
         return re.sub(r"[^a-z0-9]+", "_", str(name).lower()).strip("_")
 
     process_key_map = {_normalize_key(k): k for k in process_costs.keys()}
-    pass_key_map = {_normalize_key(k): k for k in pass_through.keys()}
+    pass_key_map = {
+        _normalize_key(_canonical_pass_label(k)): _canonical_pass_label(k)
+        for k in pass_through.keys()
+    }
+    pass_key_map[_normalize_key(LEGACY_HARDWARE_PASS_LABEL)] = HARDWARE_PASS_LABEL
 
     def _friendly_process(name: str) -> str:
         return name.replace("_", " ").title()
@@ -9515,7 +9540,7 @@ def compute_quote_from_df(df: pd.DataFrame,
 
     material_direct_cost = float(pass_through.get("Material", material_direct_cost_base))
     fixture_material_cost = float(pass_through.get("Fixture Material", fixture_material_cost_base))
-    hardware_cost = float(pass_through.get("Hardware / BOM", hardware_cost))
+    hardware_cost = float(pass_through.get(HARDWARE_PASS_LABEL, hardware_cost))
     outsourced_costs = float(pass_through.get("Outsourced Vendors", outsourced_costs))
     shipping_cost = float(pass_through.get("Shipping", shipping_cost))
     consumables_hr_cost = float(pass_through.get("Consumables /Hr", consumables_hr_cost))
@@ -9823,16 +9848,17 @@ def trace_hours_from_df(df):
 # ---------- Explanation ----------
 def explain_quote(breakdown: dict[str,Any], hour_trace=None) -> str:
     tot=breakdown.get("totals",{}); pro=breakdown.get("process_costs",{}); nre=breakdown.get("nre",{}); pt=breakdown.get("pass_through",{}); ap=breakdown.get("applied_pcts",{})
+    pt_canon={_canonical_pass_label(k):v for k,v in (pt or {}).items()}
     lines=[f"Includes Overhead {ap.get('OverheadPct',0):.0%}, Margin {ap.get('MarginPct',0):.0%}."]
     if nre.get("programming_per_part",0)>0: lines.append(f"NRE spread across lot: ${nre['programming_per_part']:.2f}")
     major={k:v for k,v in pro.items() if v and v>0}
     if major:
         top=sorted(major.items(), key=lambda kv: kv[1], reverse=True)[:4]
         lines.append("Major processes: " + ", ".join(f"{k.replace('_',' ')} ${v:,.0f}" for k,v in top))
-    if pt.get("Hardware / BOM",0) or pt.get("Outsourced Vendors",0):
+    if pt_canon.get(HARDWARE_PASS_LABEL,0) or pt_canon.get("Outsourced Vendors",0):
         lines.append(
-            f"Pass-throughs: hardware ${pt.get('Hardware / BOM',0):.0f}, "
-            f"vendors ${pt.get('Outsourced Vendors',0):.0f}, ship ${pt.get('Shipping',0):.0f}"
+            f"Pass-throughs: hardware ${pt_canon.get(HARDWARE_PASS_LABEL,0):.0f}, "
+            f"vendors ${pt_canon.get('Outsourced Vendors',0):.0f}, ship ${pt_canon.get('Shipping',0):.0f}"
         )
     if hour_trace:
         for bucket, rows in hour_trace.items():
@@ -11546,7 +11572,8 @@ def derive_inference_knobs(
                 "assembly_hours": round(assembly_hours, 3),
             },
             "targets": [
-                "add_pass_through.Hardware / BOM",
+                f"add_pass_through.{HARDWARE_PASS_LABEL}",
+                f"add_pass_through.{LEGACY_HARDWARE_PASS_LABEL}",
                 "process_hour_adders.assembly",
             ],
         }


### PR DESCRIPTION
## Summary
- rename the hardware pass-through label to "Hardware" and ensure legacy "Hardware / BOM" inputs map to the new name
- update quote explanations and alias handling so hardware costs never display as "Hardware / Bom"
- refresh variable spreadsheets to use the new "Hardware Cost" label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c5a8a9d08320abfd3654564f9fc7