### PR TITLE
Remove Consumables /Hr line from quote outputs

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -7599,7 +7599,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         "Hardware / BOM": {"basis": "Pass-through hardware / BOM"},
         "Outsourced Vendors": {"basis": "Outside processing vendors"},
         "Shipping": {"basis": "Freight & logistics"},
-        "Consumables /Hr": {"basis": "Machine & inspection hours $/hr"},
         "Utilities": {"basis": "Spindle/inspection hours $/hr"},
         "Consumables Flat": {"basis": "Fixed shop supplies"},
         "Packaging Flat": {"basis": "Packaging materials & crates"},
@@ -7622,7 +7621,6 @@ def compute_quote_from_df(df: pd.DataFrame,
         "Hardware / BOM": hardware_cost,
         "Outsourced Vendors": outsourced_costs,
         "Shipping": shipping_cost,
-        "Consumables /Hr": consumables_hr_cost,
         "Utilities": utilities_cost,
         "Consumables Flat": consumables_flat,
         "Packaging Flat": packaging_flat_base,
@@ -9518,7 +9516,6 @@ def compute_quote_from_df(df: pd.DataFrame,
     hardware_cost = float(pass_through.get("Hardware / BOM", hardware_cost))
     outsourced_costs = float(pass_through.get("Outsourced Vendors", outsourced_costs))
     shipping_cost = float(pass_through.get("Shipping", shipping_cost))
-    consumables_hr_cost = float(pass_through.get("Consumables /Hr", consumables_hr_cost))
     utilities_cost = float(pass_through.get("Utilities", utilities_cost))
     consumables_flat = float(pass_through.get("Consumables Flat", consumables_flat))
 

--- a/cad_quoter/llm.py
+++ b/cad_quoter/llm.py
@@ -102,11 +102,6 @@ SUGG_TO_EDITOR = {
             else False
         ),
     ),
-    ("add_pass_through", "Consumables /Hr"): (
-        "Consumables /Hr Cost",
-        float,
-        float,
-    ),
     ("add_pass_through", "Utilities"): (
         "Utilities Cost",
         float,


### PR DESCRIPTION
## Summary
- remove the Consumables /Hr pass-through entry so it no longer appears in quote breakdowns
- update the LLM suggestion mapping to drop the Consumables /Hr adjustment option

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c5d324f88320a7e7a6d8bd55bf4b