### PR TITLE
Rename consumables pass-through label

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -7601,7 +7601,7 @@ def compute_quote_from_df(df: pd.DataFrame,
         "Shipping": {"basis": "Freight & logistics"},
         "Consumables /Hr": {"basis": "Machine & inspection hours $/hr"},
         "Utilities": {"basis": "Spindle/inspection hours $/hr"},
-        "Consumables Flat": {"basis": "Fixed shop supplies"},
+        "Consumables": {"basis": "Fixed shop supplies"},
         "Packaging Flat": {"basis": "Packaging materials & crates"},
     }
     if material_scrap_credit_applied:
@@ -7624,7 +7624,7 @@ def compute_quote_from_df(df: pd.DataFrame,
         "Shipping": shipping_cost,
         "Consumables /Hr": consumables_hr_cost,
         "Utilities": utilities_cost,
-        "Consumables Flat": consumables_flat,
+        "Consumables": consumables_flat,
         "Packaging Flat": packaging_flat_base,
     }
     if material_scrap_credit_applied:
@@ -9520,7 +9520,7 @@ def compute_quote_from_df(df: pd.DataFrame,
     shipping_cost = float(pass_through.get("Shipping", shipping_cost))
     consumables_hr_cost = float(pass_through.get("Consumables /Hr", consumables_hr_cost))
     utilities_cost = float(pass_through.get("Utilities", utilities_cost))
-    consumables_flat = float(pass_through.get("Consumables Flat", consumables_flat))
+    consumables_flat = float(pass_through.get("Consumables", consumables_flat))
 
     labor_cost = programming_per_part + fixture_labor_per_part + sum(process_costs.values())
 


### PR DESCRIPTION
## Summary
- rename the consumables pass-through entry from "Consumables Flat" to "Consumables" so the breakdown label matches the requested text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c5f7dc0083209a09f4e9a605a985