### PR TITLE
Integrate planner-driven process costing

### DIFF
--- a/planner_pricing.py
+++ b/planner_pricing.py
@@ -1,7 +1,8 @@
-from typing import Dict, Any, Tuple
-from process_planner import plan_job
-from rates import OP_TO_MACHINE, OP_TO_LABOR, rate_for_machine, rate_for_role
+from typing import Any, Dict, Tuple
+
 import time_models as tm
+from cad_quoter.rates import OP_TO_LABOR, OP_TO_MACHINE, rate_for_machine, rate_for_role
+from process_planner import plan_job
 
 ATTENDANCE = {  # operator attendance fraction of a labor role during machine ops (optional)
     "WireEDM": 0.20,

--- a/tests/integration/test_app_smoke.py
+++ b/tests/integration/test_app_smoke.py
@@ -244,6 +244,17 @@ def test_validate_quote_allows_small_material_cost_with_thickness() -> None:
         pytest.fail(f"unexpected validation error: {exc}")
 
 
+def test_validate_quote_accepts_planner_bucket_costs() -> None:
+    geo = {"hole_diams_mm": [5.0, 5.0, 5.0]}
+    pass_through = {"Material": 12.0}
+    process_costs = {"Machine": 180.0, "Labor": 60.0}
+
+    try:
+        appV5.validate_quote_before_pricing(geo, process_costs, pass_through, {})
+    except ValueError as exc:  # pragma: no cover - should not raise
+        pytest.fail(f"unexpected validation error: {exc}")
+
+
 def test_validate_quote_blocks_when_material_unknown() -> None:
     geo = {}
     pass_through = {"Material": 0.0}

--- a/tests/test_planner_pricing.py
+++ b/tests/test_planner_pricing.py
@@ -1,0 +1,54 @@
+from planner_pricing import price_with_planner
+
+
+def test_price_with_planner_uses_geometry_minutes() -> None:
+    rates = {
+        "machine": {
+            "WireEDM": 120.0,
+            "CNC_Mill": 95.0,
+            "SurfaceGrind": 85.0,
+        },
+        "labor": {
+            "Machinist": 60.0,
+            "Finisher": 45.0,
+            "Assembler": 40.0,
+            "Inspector": 55.0,
+            "Grinder": 58.0,
+            "Engineer": 70.0,
+        },
+    }
+
+    params = {
+        "material": "tool_steel_annealed",
+        "overall_length": 3.0,
+        "min_feature_width": 0.5,
+        "min_inside_radius": 0.05,
+        "profile_tol": 0.0005,
+        "blind_relief": False,
+        "edge_condition": "sharp",
+    }
+
+    geom = {
+        "wedm": {
+            "perimeter_in": 12.0,
+            "starts": 1,
+            "tabs": 0,
+            "passes": 2,
+            "wire_in": 0.010,
+        },
+        "milling": {"volume_cuin": 8.0},
+        "sg": {"area_sq_in": 18.0, "stock_in": 0.002},
+        "drill": [{"dia_in": 0.25, "depth_in": 0.75}],
+        "length_ft_edges": 3.0,
+        "lap_area_sq_in": 1.5,
+    }
+
+    result = price_with_planner("punch", params, geom, rates, oee=1.0)
+
+    assert "ops" in result["plan"]
+    assert result["totals"]["minutes"] > 0.0
+    assert result["totals"]["machine_cost"] > 0.0
+
+    wire_items = [item for item in result["line_items"] if item["op"] == "wire_edm_outline"]
+    assert wire_items, "expected WEDM operation in planner output"
+    assert wire_items[0]["minutes"] > 1.0


### PR DESCRIPTION
## Summary
- gate the hole-cost reasonableness check so planner-produced Machine/Labor buckets pass validation.【F:appV5.py†L6531-L6542】【F:tests/integration/test_app_smoke.py†L247-L255】
- initialise planner pricing metadata, convert planner outputs into machine/labor costs, and persist the minutes + pricing breakdown onto the quote state and final report.【F:appV5.py†L7411-L7858】【F:appV5.py†L8570-L8667】【F:appV5.py†L10040-L10067】
- switch planner_pricing to cad_quoter.rates and add a regression test ensuring geometry drives minutes/costs.【F:planner_pricing.py†L1-L30】【F:tests/test_planner_pricing.py†L1-L54】

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68e5cd6ded288320ab0b62a4ffd7fa9d