### PR TITLE
Remove redundant extras lines in process detail display

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5022,18 +5022,27 @@ def render_quote(
         text = str(key or "").replace("_", " ").strip()
         return text.title() if text else ""
 
+    extra_detail_pattern = re.compile(r"^includes\b.*extras\b", re.IGNORECASE)
+
+    def _is_extra_segment(segment: str) -> bool:
+        return bool(extra_detail_pattern.match(segment))
+
     def _merge_detail(existing: str | None, new_bits: list[str]) -> str | None:
         segments: list[str] = []
         seen: set[str] = set()
         for bit in new_bits:
             seg = str(bit).strip()
-            if seg and seg not in seen:
+            if not seg or _is_extra_segment(seg):
+                continue
+            if seg not in seen:
                 segments.append(seg)
                 seen.add(seg)
         if existing:
             for segment in re.split(r";\s*", str(existing)):
                 seg = segment.strip()
-                if seg and seg not in seen:
+                if not seg or _is_extra_segment(seg):
+                    continue
+                if seg not in seen:
                     segments.append(seg)
                     seen.add(seg)
         if segments:
@@ -5339,14 +5348,11 @@ def render_quote(
                 extra_val = 0.0
             if hr_val > 0:
                 detail_bits.append(f"{hr_val:.2f} hr @ ${rate_val:,.2f}/hr")
-            if abs(extra_val) > 1e-6:
-                if hr_val <= 1e-6 and rate_val > 0:
-                    extra_hours = extra_val / rate_val
-                    detail_bits.append(
-                        f"{extra_hours:.2f} hr @ ${rate_val:,.2f}/hr"
-                    )
-                else:
-                    detail_bits.append(f"includes ${extra_val:,.2f} extras")
+            if abs(extra_val) > 1e-6 and hr_val <= 1e-6 and rate_val > 0:
+                extra_hours = extra_val / rate_val
+                detail_bits.append(
+                    f"{extra_hours:.2f} hr @ ${rate_val:,.2f}/hr"
+                )
             proc_notes = applied_process.get(str(key).lower(), {}).get("notes")
             if proc_notes:
                 detail_bits.append("LLM: " + ", ".join(proc_notes))
@@ -9841,13 +9847,17 @@ def compute_quote_from_df(df: pd.DataFrame,
         seen: set[str] = set()
         for bit in detail_bits:
             seg = str(bit).strip()
-            if seg and seg not in seen:
+            if not seg or _is_extra_segment(seg):
+                continue
+            if seg not in seen:
                 merged_bits.append(seg)
                 seen.add(seg)
         if existing_detail:
             for segment in re.split(r";\s*", existing_detail):
                 seg = segment.strip()
-                if seg and seg not in seen:
+                if not seg or _is_extra_segment(seg):
+                    continue
+                if seg not in seen:
                     merged_bits.append(seg)
                     seen.add(seg)
         if merged_bits:
@@ -9865,9 +9875,6 @@ def compute_quote_from_df(df: pd.DataFrame,
             detail_bits.append(f"{hr:.2f} hr @ ${rate:,.2f}/hr")
         elif hr > 0:
             detail_bits.append(f"{hr:.2f} hr")
-
-        if abs(extra) > 1e-6:
-            detail_bits.append(f"includes ${extra:,.2f} extras")
 
         proc_notes = applied_process.get(key, {}).get("notes")
         if proc_notes:

--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -160,8 +160,7 @@ def test_render_quote_does_not_duplicate_detail_lines() -> None:
     assert "Fixture Build (amortized)" in rendered
     assert "- Programmer (lot): 1.00 hr @ $75.00/hr" in rendered
     assert "- Build labor (lot): 0.50 hr @ $60.00/hr" in rendered
-    assert rendered.count("includes $200.00 extras") == 1
-    assert rendered.count("includes 1.67 hr extras") == 0
+    assert "includes $200.00 extras" not in rendered
     assert rendered.count("1.50 hr @ $120.00/hr") == 1
 
 


### PR DESCRIPTION
## Summary
- filter out "includes ... extras" detail segments when rendering process and labor summaries
- only convert flat extras to equivalent hours when no process hours exist instead of listing extras text
- update the quote rendering test to reflect the streamlined labor detail output

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d37fddbc8320a291dbd4efabbea3