### PR TITLE
Update weight display formatting

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5161,8 +5161,17 @@ def render_quote(
                     diff_mass = abs(float(effective_mass_val) - float(net_mass_val))
                     base_candidate = max(float(effective_mass_val), float(net_mass_val))
                     scrap_adjusted_mass_val = max(0.0, base_candidate - diff_mass)
+            starting_mass_val = _coerce_float_or_none(material.get("effective_mass_g"))
+            if starting_mass_val is None:
+                starting_mass_val = effective_mass_val
             if net_mass_val is None:
                 net_mass_val = effective_mass_val
+            if (
+                net_mass_val is None
+                and starting_mass_val is not None
+                and removal_mass_val is not None
+            ):
+                net_mass_val = max(0.0, float(starting_mass_val) - float(removal_mass_val))
             show_mass_line = (
                 (net_mass_val and net_mass_val > 0)
                 or (effective_mass_val and effective_mass_val > 0)
@@ -5189,19 +5198,50 @@ def render_quote(
                         f"scrap-adjusted {_format_weight_lb_decimal(effective_mass_val)}"
                     )
 
+            scrap_mass_val: float | None = None
+            if (
+                starting_mass_val is not None
+                and net_mass_val is not None
+            ):
+                scrap_mass_val = max(0.0, float(starting_mass_val) - float(net_mass_val))
+            if scrap_mass_val is None and removal_mass_val is not None:
+                scrap_mass_val = max(0.0, float(removal_mass_val))
+            if (
+                scrap_mass_val is None
+                and scrap_fraction_val is not None
+                and starting_mass_val is not None
+            ):
+                scrap_mass_val = max(
+                    0.0, float(starting_mass_val) * float(scrap_fraction_val)
+                )
+            if (
+                scrap_mass_val is None
+                and scrap_adjusted_mass_val is not None
+                and net_mass_val is not None
+            ):
+                scrap_mass_val = max(
+                    0.0,
+                    abs(float(scrap_adjusted_mass_val) - float(net_mass_val)),
+                )
+
+            if (starting_mass_val and starting_mass_val > 0) or show_zeros:
+                write_line(
+                    f"Starting Weight: {_format_weight_lb_oz(starting_mass_val)}",
+                    "  ",
+                )
+            if scrap_mass_val is not None:
+                if scrap_mass_val > 0 or show_zeros:
+                    write_line(
+                        f"Scrap Weight: {_format_weight_lb_oz(scrap_mass_val)}",
+                        "  ",
+                    )
+            elif show_zeros:
+                write_line("Scrap Weight: 0 oz", "  ")
             if (net_mass_val and net_mass_val > 0) or show_zeros:
-                write_line(f"Net Weight: {_format_weight_lb_oz(net_mass_val)}", "  ")
-            with_scrap_mass = scrap_adjusted_mass_val
-            if with_scrap_mass is None:
-                with_scrap_mass = effective_mass_val if scrap else None
-            if with_scrap_mass is not None:
-                show_with_scrap = False
-                if net_mass_val:
-                    show_with_scrap = abs(float(with_scrap_mass) - float(net_mass_val)) > 0.05
-                else:
-                    show_with_scrap = bool(with_scrap_mass) or show_zeros
-                if show_with_scrap or show_zeros:
-                    write_line(f"With Scrap: {_format_weight_lb_oz(with_scrap_mass)}", "  ")
+                write_line(
+                    f"Net Weight: {_format_weight_lb_oz(net_mass_val)}",
+                    "  ",
+                )
 
             if upg or unit_price_kg or unit_price_lb or show_zeros:
                 grams_per_lb = 1000.0 / LB_PER_KG

--- a/tests/app/test_material_density.py
+++ b/tests/app/test_material_density.py
@@ -61,8 +61,9 @@ def test_render_quote_displays_weight_in_pounds_ounces() -> None:
 
     text = render_quote(result)
 
+    assert "Starting Weight: 13 lb 3.6 oz" in text
+    assert "Scrap Weight: 7.1 oz" in text
     assert "Net Weight: 12 lb 12.6 oz" in text
-    assert "With Scrap: 12 lb 2.4 oz" in text
     weight_lines = "\n".join(
         line for line in text.splitlines() if "Weight" in line or "Mass" in line
     )

--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -42,8 +42,9 @@ def test_render_quote_shows_net_mass_when_scrap_present() -> None:
     rendered = appV5.render_quote(result, currency="$", show_zeros=False)
 
     assert "Mass:" not in rendered
+    assert "Starting Weight: 4.2 oz" in rendered
+    assert "Scrap Weight: 0.71 oz" in rendered
     assert "Net Weight: 3.5 oz" in rendered
-    assert "With Scrap: 2.8 oz" in rendered
 
 
 def _base_material_quote(material: dict) -> dict:


### PR DESCRIPTION
## Summary
- show starting, scrap, and net weight lines when rendering material details
- derive scrap weight from available mass, removal, or scrap fraction inputs
- update rendering tests to cover the new weight presentation

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py::test_render_quote_shows_net_mass_when_scrap_present -q
- pytest tests/app/test_material_density.py::test_render_quote_displays_weight_in_pounds_ounces -q

------
https://chatgpt.com/codex/tasks/task_e_68e5d4dbdaa8832097a4e15bee77b7cd