### PR TITLE
Define shared extra segment helper for labor detail merge

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -55,6 +55,15 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Seque
 import cad_quoter.geometry as geometry
 
 
+EXTRA_DETAIL_PATTERN = re.compile(r"^includes\b.*extras\b", re.IGNORECASE)
+
+
+def _is_extra_segment(segment: str) -> bool:
+    """Return True when a labor detail segment only repeats extras info."""
+
+    return bool(EXTRA_DETAIL_PATTERN.match(str(segment).strip()))
+
+
 ensure_runtime_dependencies = _runtime.ensure_runtime_dependencies
 find_default_qwen_model = _runtime.find_default_qwen_model
 load_qwen_vl = _runtime.load_qwen_vl
@@ -5021,11 +5030,6 @@ def render_quote(
     def _process_label(key: str | None) -> str:
         text = str(key or "").replace("_", " ").strip()
         return text.title() if text else ""
-
-    extra_detail_pattern = re.compile(r"^includes\b.*extras\b", re.IGNORECASE)
-
-    def _is_extra_segment(segment: str) -> bool:
-        return bool(extra_detail_pattern.match(segment))
 
     def _merge_detail(existing: str | None, new_bits: list[str]) -> str | None:
         segments: list[str] = []


### PR DESCRIPTION
## Summary
- hoist the extra segment detection regex and helper to module scope
- reuse the shared helper from both render and compute quote labor merging paths to avoid NameError

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d6a426fc8320a1ae94d917f8dfe7