### PR TITLE
Hide outsourced vendor pass-through row when unused

### DIFF
--- a/tests/pricing/test_outsourced_vendor_visibility.py
+++ b/tests/pricing/test_outsourced_vendor_visibility.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import appV5
+
+
+def test_outsourced_pass_hidden_without_geo_or_cost() -> None:
+    assert not appV5._should_include_outsourced_pass(0.0, {})
+
+
+def test_outsourced_pass_shown_when_cost_present() -> None:
+    assert appV5._should_include_outsourced_pass(12.5, {})
+
+
+def test_outsourced_pass_shown_when_geo_lists_finishes() -> None:
+    geo = {"finishes": ["Anodize Type II"]}
+    assert appV5._should_include_outsourced_pass(0.0, geo)
+
+
+def test_outsourced_pass_shown_when_nested_geo_has_finish_flags() -> None:
+    geo = {"geo": {"finish_flags": ["PASSIVATION"]}}
+    assert appV5._should_include_outsourced_pass(0.0, geo)
+
+
+def test_outsourced_pass_hidden_for_blank_finish_entries() -> None:
+    geo = {"finishes": ["", None, "  "], "finish_flags": []}
+    assert not appV5._should_include_outsourced_pass(0.0, geo)


### PR DESCRIPTION
## Summary
- add helpers to detect outsourced-finish signals in the geo context
- omit the "Outsourced Vendors" pass-through when there is no cost or outsourced mention
- add unit coverage for the visibility helper

## Testing
- pytest tests/pricing/test_outsourced_vendor_visibility.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d3d7c4d08320b783bfe956c16b69