### PR TITLE
Fix scrap credit detail line assembly

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5141,8 +5141,7 @@ def render_quote(
                 )
                 if scrap_credit_mass_lb and scrap_credit_unit_price_lb:
                     detail_lines.append(
-                        "    based on "
-                        f"{float(scrap_credit_mass_lb):.2f} lb × {currency}{float(scrap_credit_unit_price_lb):,.2f} / lb"
+                        f"    based on {float(scrap_credit_mass_lb):.2f} lb × {currency}{float(scrap_credit_unit_price_lb):,.2f} / lb"
                     )
             net_mass_val = _coerce_float_or_none(net_mass_g)
             effective_mass_val = _coerce_float_or_none(mass_g)


### PR DESCRIPTION
## Summary
- ensure the scrap credit detail line is appended as a single string so rendering succeeds when both values are present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5d696058c8320b59e896b35f16899