### PR TITLE
Smooth inspection hour defaults based on tolerance precision

### DIFF
--- a/tests/app/test_tolerance_estimation.py
+++ b/tests/app/test_tolerance_estimation.py
@@ -1,0 +1,18 @@
+from appV5 import _estimate_inprocess_default_from_tolerance
+
+
+def test_inspection_hours_scale_with_tolerance_precision():
+    loose = _estimate_inprocess_default_from_tolerance({"Default": "±0.005"})
+    medium = _estimate_inprocess_default_from_tolerance({"Default": "±0.001"})
+    tight = _estimate_inprocess_default_from_tolerance({"Default": "±0.0002"})
+
+    assert loose < medium < tight
+
+
+def test_multiple_tight_callouts_add_sublinear_premium():
+    single = _estimate_inprocess_default_from_tolerance({"Tol A": "±0.0006"})
+    stacked = _estimate_inprocess_default_from_tolerance(
+        {"Tol A": "±0.0006", "Tol B": "±0.0004", "Tol C": "±0.0004"}
+    )
+
+    assert stacked - single < single  # premium should not double the base


### PR DESCRIPTION
## Summary
- tie the default in-process inspection estimate to a smooth tolerance-based curve with bounded premiums for tight callouts
- add regression tests to confirm tighter tolerances raise the default while multiple callouts stay sub-linear

## Testing
- pytest tests/app/test_tolerance_estimation.py

------
https://chatgpt.com/codex/tasks/task_e_68e65cc6aeb48320bd24c5c9b1af18f7