### PR TITLE
Fix net mass display when using net_mass_g

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5144,6 +5144,10 @@ def render_quote(
     if material:
         mass_g = material.get("mass_g")
         net_mass_g = material.get("mass_g_net")
+        if _coerce_float_or_none(net_mass_g) is None:
+            fallback_net_mass = material.get("net_mass_g")
+            if _coerce_float_or_none(fallback_net_mass) is not None:
+                net_mass_g = fallback_net_mass
         upg    = material.get("unit_price_per_g")
         minchg = material.get("supplier_min_charge")
         matcost= material.get("material_cost")
@@ -5227,14 +5231,18 @@ def render_quote(
             starting_mass_val = _coerce_float_or_none(material.get("effective_mass_g"))
             if starting_mass_val is None:
                 starting_mass_val = effective_mass_val
-            if net_mass_val is None:
-                net_mass_val = effective_mass_val
             if (
                 net_mass_val is None
-                and starting_mass_val is not None
                 and removal_mass_val is not None
+                and removal_mass_val >= 0
             ):
-                net_mass_val = max(0.0, float(starting_mass_val) - float(removal_mass_val))
+                base_for_net = starting_mass_val
+                if base_for_net is None:
+                    base_for_net = effective_mass_val
+                if base_for_net is not None:
+                    net_mass_val = max(0.0, float(base_for_net) - float(removal_mass_val))
+            if net_mass_val is None:
+                net_mass_val = effective_mass_val
             show_mass_line = (
                 (net_mass_val and net_mass_val > 0)
                 or (effective_mass_val and effective_mass_val > 0)

--- a/tests/pricing/test_render_quote_mass_display.py
+++ b/tests/pricing/test_render_quote_mass_display.py
@@ -47,6 +47,25 @@ def test_render_quote_shows_net_mass_when_scrap_present() -> None:
     assert "Net Weight: 3.5 oz" in rendered
 
 
+def test_render_quote_uses_net_mass_g_fallback() -> None:
+    start_g = 14866.489927078912
+    net_g = 11149.867445309184
+    material = {
+        "mass_g": start_g,
+        "effective_mass_g": start_g,
+        "net_mass_g": net_g,
+        "scrap_pct": 0.25,
+    }
+
+    result = _base_material_quote(material)
+
+    rendered = appV5.render_quote(result, currency="$", show_zeros=False)
+
+    assert "Starting Weight: 32 lb 12.4 oz" in rendered
+    assert "Scrap Weight: 8 lb 3.1 oz" in rendered
+    assert "Net Weight: 24 lb 9.3 oz" in rendered
+
+
 def _base_material_quote(material: dict) -> dict:
     return {
         "price": 10.0,


### PR DESCRIPTION
## Summary
- ensure `render_quote` falls back to `net_mass_g` when `mass_g_net` is missing
- adjust net-mass calculation to use removal mass before falling back to effective mass
- add a regression test that covers weight formatting when only `net_mass_g` is provided

## Testing
- pytest tests/pricing/test_render_quote_mass_display.py

------
https://chatgpt.com/codex/tasks/task_e_68e65b975f108320a6ff6f27e65b8219