### PR TITLE
Remove 'With Scrap' label from material weight display

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5341,9 +5341,7 @@ def render_quote(
                 else:
                     show_with_scrap = bool(with_scrap_mass) or show_zeros
                 if show_with_scrap or show_zeros:
-                    weight_lines.append(
-                        f"  With Scrap: {_format_weight_lb_oz(with_scrap_mass)}"
-                    )
+                    weight_lines.append(f"{_format_weight_lb_oz(with_scrap_mass)}")
 
             detail_lines.extend(weight_lines)
             if scrap_credit_lines:


### PR DESCRIPTION
## Summary
- remove the "With Scrap:" label from the material and stock weight list so only the value remains
- eliminate the extra leading whitespace that accompanied the label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66a6d58508320905e3ce440188e47