### PR TITLE
Exclude material from pass-through summary

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -5644,6 +5644,8 @@ def render_quote(
     lines.append(divider)
     pass_total = 0.0
     for key, value in sorted((pass_through or {}).items(), key=lambda kv: kv[1], reverse=True):
+        if key == "Material":
+            continue
         if (value > 0) or show_zeros:
             # cosmetic: "consumables_hr_cost" → "Consumables /Hr Cost"
             label = key.replace("_", " ").replace("hr", "/hr").title()


### PR DESCRIPTION
## Summary
- skip the Material entry when rendering the Pass-Through & Direct Costs table so it no longer appears in the breakdown

## Testing
- pytest *(fails: network access blocked while scraping Wieland material prices)*

------
https://chatgpt.com/codex/tasks/task_e_68e66a738fc48320a671beef6ab29b3b