### PR TITLE
Simplify shipping basis description

### DIFF
--- a/appV5.py
+++ b/appV5.py
@@ -8066,11 +8066,7 @@ def compute_quote_from_df(df: pd.DataFrame,
     insurance_pct     = num_pct(r"(?:Insurance|Liability\s*Adder)", params["InsurancePct"])
     packaging_cost    = packaging_hr * rates["AssemblyRate"] + crate_nre_cost + packaging_mat
     packaging_flat_base = float((crate_nre_cost or 0.0) + (packaging_mat or 0.0))
-    shipping_basis_desc = (
-        f"Freight & logistics (~{shipping_pct_of_material:.0%} of material)"
-        if shipping_pct_of_material
-        else "Freight & logistics"
-    )
+    shipping_basis_desc = "Freight & logistics"
     shipping_cost_base = float(shipping_cost)
 
     # EHS / compliance


### PR DESCRIPTION
## Summary
- remove the material percentage from the shipping basis description so it always displays "Freight & logistics"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e66a79c79c8320a0224a76f8e5e23e