### PR TITLE
Implement geometry-driven planner pricing

### DIFF
--- a/planner_pricing.py
+++ b/planner_pricing.py
@@ -1,135 +1,266 @@
+from __future__ import annotations
+
+from math import log1p, sqrt
 from typing import Any, Dict, Tuple
 
-import time_models as tm
-from cad_quoter.rates import OP_TO_LABOR, OP_TO_MACHINE, rate_for_machine, rate_for_role
 from process_planner import plan_job
 
-ATTENDANCE = {  # operator attendance fraction of a labor role during machine ops (optional)
-    "WireEDM": 0.20,
-    "SinkerEDM": 0.40,
-    "CNC_Mill": 0.25,
-    "SurfaceGrind": 0.35,
-    "JigGrind": 0.60,
-    "Waterjet": 0.20,
-    "Blanchard": 0.30,
-    "DrillPress": 0.50,
-}
+
+# -------- helpers
+
+def _get_rate(rates2: dict, bucket: str, key: str, default: float = 90.0) -> float:
+    try:
+        return float(rates2.get(bucket, {}).get(key, default) or default)
+    except Exception:
+        return default
 
 
-def minutes_for_op(op: Dict[str, Any], geom: Dict[str, Any]) -> float:
-    """Map a planner op to a minute model using geom hints."""
-    name = op["op"]
+def _as_float(x, default=None):
+    try:
+        return float(x)
+    except Exception:
+        return default
 
-    if name in ("wire_edm_windows", "wire_edm_outline"):
-        d = dict(geom.get("wedm", {}))
-        # let planner override passes/wire if provided
-        if "passes" in op.get("params", op):
-            d["passes"] = int(str(op.get("passes", "R+1S").split('+')[-1][0] or 1))
-        if "wire_in" in op:
-            d["wire_in"] = op["wire_in"]
-        return tm.minutes_wedm(d)
 
-    if name in (
-        "surface_grind_faces",
-        "surface_or_profile_grind_bearing",
-        "profile_or_surface_grind_wear_faces",
-    ):
-        return tm.minutes_surface_grind(geom.get("sg", {}))
+def _geom(geom: dict) -> dict:
+    """Normalize geometry payload into scalar values used by the models."""
 
-    if name == "blanchard_grind_pre":
-        return tm.minutes_blanchard(geom.get("blanchard", {}))
+    d = dict(geom or {})
+    derived = d.get("derived") if isinstance(d.get("derived"), dict) else {}
+    out: Dict[str, Any] = {}
 
-    if name in ("cnc_rough_mill", "finish_mill_windows", "thread_mill"):
-        return tm.minutes_mill(geom.get("milling", {}))
+    def g(*keys, default=None):
+        for k in keys:
+            v = d.get(k, None)
+            if v is None:
+                k_derived = k.split(".", 1)[-1]
+                if k_derived in derived:
+                    v = derived.get(k_derived)
+            if v is not None:
+                return v
+        return default
 
-    if name in ("drill_patterns", "drill_ream_bore", "drill_ream_dowel_press"):
-        return tm.minutes_drill(geom.get("drill", []))
+    out["hole_count"] = int(_as_float(g("hole_count", "derived.hole_count"), 0) or 0)
+    out["tap_qty"] = int(_as_float(g("tap_qty"), 0) or 0)
+    out["cbore_qty"] = int(_as_float(g("cbore_qty"), 0) or 0)
+    out["slot_count"] = int(_as_float(g("slot_count"), 0) or 0)
+    out["edge_len_in"] = _as_float(g("edge_len_in"), 0.0) or 0.0
+    out["pocket_area_in2"] = _as_float(g("pocket_area_total_in2"), 0.0) or 0.0
+    out["plate_area_in2"] = _as_float(g("plate_area_in2"), 0.0) or 0.0
+    out["thickness_in"] = _as_float(g("thickness_in"), None)
+    if out["thickness_in"] is None:
+        mm = _as_float(g("thickness_mm"), 0.0) or 0.0
+        out["thickness_in"] = mm / 25.4 if mm else 0.0
+    return out
 
-    if name == "rigid_tap":
-        return tm.minutes_tap(geom.get("tapped_count", 0))
 
-    if name in (
-        "jig_bore_or_jig_grind_coaxial_bores",
-        "jig_grind_ID_to_size_and_roundness",
-        "jig_bore",
-    ):
-        return tm.minutes_bores(geom.get("bores", []))
+def _material_factor(material: str | None) -> Tuple[float, float]:
+    """Return (mrr_in3_per_min, grind_area_rate_in2_per_min) rough factors by material."""
 
-    if name in ("sinker_edm_finish_burn",):
-        return tm.minutes_sinker(geom.get("sinker", []))
+    m = (material or "").lower()
+    if "al" in m or "aluminum" in m:
+        return (3.0, 220.0)
+    if "cast" in m:
+        return (2.0, 180.0)
+    if "ss" in m or "stainless" in m:
+        return (1.0, 120.0)
+    return (1.5, 160.0)  # default steels
 
-    if name in ("edge_break",):
-        return tm.minutes_edgebreak(geom.get("length_ft_edges", 0.0))
 
-    if name in ("lap_bearing_land", "lap_ID"):
-        return tm.minutes_lap(geom.get("lap_area_sq_in", 0.0))
+# -------- curved models (no hard caps)
 
-    # default small overhead if nothing matched
-    return 0.5
+def _inspection_minutes(geom: dict, tol: dict) -> float:
+    n_holes = max(0, int(geom["hole_count"]))
+    edge_len = max(0.0, float(geom["edge_len_in"]))
+    slots = max(0, int(geom["slot_count"]))
+
+    def _tight_score(x, ref):
+        if x is None or x <= 0:
+            return 0.0
+        r = ref / max(x, 1e-6)
+        return log1p(r)
+
+    score = 0.0
+    score += _tight_score(tol.get("profile_tol"), 0.001)
+    score += _tight_score(tol.get("flatness_spec"), 0.001)
+    score += _tight_score(tol.get("parallelism_spec"), 0.001)
+
+    base = 18.0
+    features = 1.8 * sqrt(n_holes)
+    geometry = 0.04 * edge_len + 0.5 * slots
+    tight = 22.0 * score
+    return base + features + geometry + tight
+
+
+def _fixture_build_minutes(setups: int, geom: dict, tol: dict) -> float:
+    n_holes = max(0, int(geom["hole_count"]))
+    flat = tol.get("flatness_spec")
+    term_setup = 18.0 * max(1, setups)
+    term_holes = 0.06 * sqrt(n_holes)
+    term_precision = 6.0 if (flat and flat <= 0.001) else 0.0
+    return term_setup + term_holes + term_precision
+
+
+def _drilling_minutes(geom: dict, thickness_in: float, taps: int, cbrores: int, holes: int) -> float:
+    approach = 10.0
+    peck = 6.0
+    pecks = max(1, int(1 + thickness_in / 0.5))
+    drill_penetration = max(0.6, 1.2 - 0.3 * thickness_in)
+    cut = 60.0 * (thickness_in / drill_penetration)
+    per_hole = approach + pecks * peck + cut
+    taps_term = 12.0 * max(0, taps)
+    cbore_term = 20.0 * max(0, cbrores)
+    return (holes * per_hole + taps_term + cbore_term) / 60.0
+
+
+def _milling_minutes(geom: dict, thickness_in: float, mrr_in3_min: float) -> float:
+    pocket_vol = max(0.0, float(geom["pocket_area_in2"])) * max(0.0, thickness_in)
+    edge_len = max(0.0, float(geom["edge_len_in"]))
+    rough = (pocket_vol / max(0.2, mrr_in3_min)) * 60.0
+    finish = (edge_len / max(10.0, 50.0)) * 60.0
+    return rough + finish
+
+
+def _grind_minutes(plate_area_in2: float, passes: int, grind_rate_in2_per_min: float) -> float:
+    setup = 8.0
+    sweep = max(1, passes) * (plate_area_in2 / max(60.0, grind_rate_in2_per_min))
+    return setup + sweep
+
+
+def _wedm_minutes(cut_len_in: float, thickness_in: float, skims: int) -> float:
+    base_ipm = 0.23 / max(0.4, thickness_in)
+    rough = (cut_len_in / max(0.05, base_ipm))
+    skim = 1.8 * skims * (cut_len_in / max(0.3, 3.0 * base_ipm))
+    return rough + skim
 
 
 def price_with_planner(
     family: str,
-    params: Dict[str, Any],
-    geom: Dict[str, Any],
-    rates: Dict[str, Dict[str, float]],
+    planner_inputs: Dict[str, Any],
+    geom_payload: Dict[str, Any],
+    two_bucket_rates: Dict[str, Dict[str, float]],
+    *,
     oee: float = 0.85,
 ) -> Dict[str, Any]:
     """
-    Run the planner, compute per-op minutes, convert to dollars with machine & labor buckets.
-    Returns {plan, line_items:[{op, min, machine$, labor$}], totals:{machine$, labor$, minutes}}
+    Return planner-driven pricing including minute models and two-bucket costs.
     """
-    plan = plan_job(family, params)
+
+    plan = plan_job(family, planner_inputs)
+    ops = [op.get("op") for op in plan.get("ops", [])]
+
+    g = _geom(geom_payload)
+    t = {
+        "profile_tol": _as_float(planner_inputs.get("profile_tol")),
+        "flatness_spec": _as_float(planner_inputs.get("flatness_spec")),
+        "parallelism_spec": _as_float(planner_inputs.get("parallelism_spec")),
+    }
+    material = str(planner_inputs.get("material") or "").strip()
+    mrr, grind_rate = _material_factor(material)
+    thickness = float(g["thickness_in"] or 0.0)
+    setups = int(_as_float(geom_payload.get("setups"), 0) or 2)
+
+    minutes: Dict[str, float] = {}
+
+    minutes["Inspection"] = _inspection_minutes(g, t)
+    minutes["Fixture Build (amortized)"] = _fixture_build_minutes(setups, g, t)
+
+    total_cut_guess_hr = (
+        _milling_minutes(g, thickness, mrr)
+        + _drilling_minutes(g, thickness, g["tap_qty"], g["cbore_qty"], g["hole_count"])
+    ) / 60.0
+    minutes["Programming (amortized)"] = max(21.0, 12.0 + 9.0 * log1p(total_cut_guess_hr))
+
+    minutes["Milling"] = _milling_minutes(g, thickness, mrr)
+    minutes["Drilling"] = _drilling_minutes(g, thickness, g["tap_qty"], g["cbore_qty"], g["hole_count"])
+
+    if any(k in ops for k in ("wire_edm_windows", "wire_edm_cam_slot_or_profile", "wire_edm_outline")):
+        skims = 0
+        for op in plan.get("ops", []):
+            if op.get("op") == "wire_edm_windows":
+                txt = str(op.get("passes") or "")
+                if "R+" in txt and "S" in txt:
+                    try:
+                        skims = int(txt.split("R+")[1].split("S")[0])
+                    except Exception:
+                        pass
+        cut_len = max(0.0, float(g["edge_len_in"]))
+        minutes["Wire EDM"] = _wedm_minutes(cut_len, thickness, skims)
+
+    grind_passes = 0
+    if (
+        "blanchard_grind_pre" in ops
+        or "surface_grind_faces/pads_to_final" in ops
+        or t["flatness_spec"]
+        or t["parallelism_spec"]
+    ):
+        grind_passes = 1
+        if t["flatness_spec"] and t["flatness_spec"] <= 0.001:
+            grind_passes += 1
+        if t["parallelism_spec"] and t["parallelism_spec"] <= 0.001:
+            grind_passes += 1
+    if grind_passes:
+        minutes["Grinding"] = _grind_minutes(g.get("plate_area_in2", 0.0), grind_passes, grind_rate)
+
+    minutes["Deburr"] = 4.0 + 0.6 * sqrt(max(0, g["hole_count"])) + 0.02 * max(0.0, g["edge_len_in"])
+
     line_items = []
-    total_machine = total_labor = total_min = 0.0
+    labor_min = 0.0
+    machine_min = 0.0
+    labor_cost = 0.0
+    machine_cost = 0.0
 
-    for op in plan["ops"]:
-        # uniform access to op params (we allowed dict merging earlier)
-        if "params" not in op:
-            op["params"] = {k: v for k, v in op.items() if k not in ("op",)}
-        minutes = minutes_for_op(op, geom)
-        total_min += minutes
+    def _add(name: str, bucket: str, rate_key: str) -> None:
+        nonlocal labor_min, machine_min, labor_cost, machine_cost
+        mins = float(minutes.get(name, 0.0) or 0.0)
+        if mins <= 0:
+            return
+        rate = _get_rate(two_bucket_rates, "labor" if bucket == "labor" else "machine", rate_key, 90.0)
+        if bucket == "machine" and oee > 0:
+            effective_minutes = mins / max(oee, 0.01)
+        else:
+            effective_minutes = mins
+        cost = (effective_minutes / 60.0) * rate
+        entry: Dict[str, Any] = {"name": name, "minutes": round(mins, 2)}
+        entry[f"{bucket}_cost"] = round(cost, 2)
+        line_items.append(entry)
+        if bucket == "labor":
+            labor_min += mins
+            labor_cost += cost
+        else:
+            machine_min += mins
+            machine_cost += cost
 
-        m_cost = l_cost = 0.0
-        # Machine $ (OEE as availability penalty)
-        if op["op"] in OP_TO_MACHINE:
-            mname = OP_TO_MACHINE[op["op"]]
-            rate = rate_for_machine(rates, mname)
-            m_cost = rate * (minutes / 60.0) / max(0.10, oee)  # divide by OEE to inflate time
+    _add("Inspection", "labor", "InspectionRate")
+    _add("Fixture Build (amortized)", "labor", "FixtureBuildRate")
+    _add("Programming (amortized)", "labor", "ProgrammingRate")
+    _add("Deburr", "labor", "DeburrRate")
+    _add("Drilling", "machine", "DrillingRate")
+    _add("Milling", "machine", "MillingRate")
+    _add("Wire EDM", "machine", "WireEDMRate")
+    _add("Grinding", "machine", "SurfaceGrindRate")
 
-            # optional attended labor
-            attend = ATTENDANCE.get(mname, 0.0)
-            if attend > 0:
-                try:
-                    lrate = rate_for_role(rates, "EDMOperator" if "EDM" in mname else "Machinist")
-                    l_cost += attend * lrate * (minutes / 60.0)
-                except KeyError:
-                    pass
-
-        # Labor-only $
-        if op["op"] in OP_TO_LABOR:
-            role = OP_TO_LABOR[op["op"]]
-            lrate = rate_for_role(rates, role)
-            l_cost += lrate * (minutes / 60.0)
-
-        line_items.append(
-            {
-                "op": op["op"],
-                "minutes": minutes,
-                "machine_cost": round(m_cost, 2),
-                "labor_cost": round(l_cost, 2),
-            }
-        )
-        total_machine += m_cost
-        total_labor += l_cost
+    total_minutes = labor_min + machine_min
+    total_cost = labor_cost + machine_cost
 
     return {
         "plan": plan,
         "line_items": line_items,
         "totals": {
-            "minutes": round(total_min, 1),
-            "machine_cost": round(total_machine, 2),
-            "labor_cost": round(total_labor, 2),
-            "total_cost": round(total_machine + total_labor, 2),
+            "labor_minutes": round(labor_min, 2),
+            "machine_minutes": round(machine_min, 2),
+            "total_minutes": round(total_minutes, 2),
+            "minutes": round(total_minutes, 2),
+            "labor_cost": round(labor_cost, 2),
+            "machine_cost": round(machine_cost, 2),
+            "total_cost": round(total_cost, 2),
+        },
+        "assumptions": {
+            "family": family,
+            "setups": setups,
+            "material": material,
+            "thickness_in": thickness,
+            "tolerances": t,
+            "oee": oee,
         },
     }

--- a/tests/test_planner_pricing.py
+++ b/tests/test_planner_pricing.py
@@ -4,51 +4,44 @@ from planner_pricing import price_with_planner
 def test_price_with_planner_uses_geometry_minutes() -> None:
     rates = {
         "machine": {
-            "WireEDM": 120.0,
-            "CNC_Mill": 95.0,
-            "SurfaceGrind": 85.0,
+            "WireEDMRate": 120.0,
+            "MillingRate": 95.0,
+            "DrillingRate": 80.0,
+            "SurfaceGrindRate": 85.0,
         },
         "labor": {
-            "Machinist": 60.0,
-            "Finisher": 45.0,
-            "Assembler": 40.0,
-            "Inspector": 55.0,
-            "Grinder": 58.0,
-            "Engineer": 70.0,
+            "InspectionRate": 55.0,
+            "FixtureBuildRate": 60.0,
+            "ProgrammingRate": 70.0,
+            "DeburrRate": 42.0,
         },
     }
 
     params = {
         "material": "tool_steel_annealed",
-        "overall_length": 3.0,
-        "min_feature_width": 0.5,
-        "min_inside_radius": 0.05,
         "profile_tol": 0.0005,
-        "blind_relief": False,
-        "edge_condition": "sharp",
+        "flatness_spec": 0.0008,
+        "parallelism_spec": 0.0012,
     }
 
     geom = {
-        "wedm": {
-            "perimeter_in": 12.0,
-            "starts": 1,
-            "tabs": 0,
-            "passes": 2,
-            "wire_in": 0.010,
-        },
-        "milling": {"volume_cuin": 8.0},
-        "sg": {"area_sq_in": 18.0, "stock_in": 0.002},
-        "drill": [{"dia_in": 0.25, "depth_in": 0.75}],
-        "length_ft_edges": 3.0,
-        "lap_area_sq_in": 1.5,
+        "hole_count": 16,
+        "tap_qty": 4,
+        "cbore_qty": 2,
+        "slot_count": 3,
+        "edge_len_in": 24.0,
+        "pocket_area_total_in2": 12.0,
+        "plate_area_in2": 60.0,
+        "thickness_in": 1.5,
+        "setups": 3,
     }
 
-    result = price_with_planner("punch", params, geom, rates, oee=1.0)
+    result = price_with_planner("die_plate", params, geom, rates, oee=0.9)
 
     assert "ops" in result["plan"]
-    assert result["totals"]["minutes"] > 0.0
-    assert result["totals"]["machine_cost"] > 0.0
+    assert result["totals"]["total_minutes"] > 0.0
+    assert result["totals"]["total_cost"] > 0.0
 
-    wire_items = [item for item in result["line_items"] if item["op"] == "wire_edm_outline"]
-    assert wire_items, "expected WEDM operation in planner output"
-    assert wire_items[0]["minutes"] > 1.0
+    edm_items = [item for item in result["line_items"] if item["name"] == "Wire EDM"]
+    assert edm_items, "expected Wire EDM line item from planner output"
+    assert edm_items[0]["minutes"] > 1.0


### PR DESCRIPTION
## Summary
- replace the planner pricing module with a geometry and tolerance driven minute model that prices labor and machine buckets
- compute per-process minutes from the planner ops, apply two-bucket rate keys, and expose assumptions for transparency
- update the unit test to exercise the new pricing curve against die-plate geometry and two-bucket rates

## Testing
- pytest tests/test_planner_pricing.py

------
https://chatgpt.com/codex/tasks/task_e_68e674344ccc8320b01e35f0f1a3d3d7