### PR TITLE
Fix pricing rounding to ensure job and per-unit totals align

### DIFF
--- a/AppV7.py
+++ b/AppV7.py
@@ -2430,8 +2430,9 @@ class AppV7:
         margin_text = f"{safe_margin:.0%}"
         if is_current:
             margin_text += " (current)"
-        final_price_per_unit = total_cost * (1.0 + safe_margin)
-        final_price_job = final_price_per_unit * quantity
+        # Job-first approach: calculate job total, round it, then derive per-unit
+        final_price_job = round(total_cost * (1.0 + safe_margin), 2)
+        final_price_per_unit = final_price_job / quantity
         price_text = f"${final_price_job:>12,.2f} (${final_price_per_unit:.2f} /unit)"
         return f" {margin_text:<17}{price_text}"
 

--- a/cad_quoter/pricing/QuoteDataHelper.py
+++ b/cad_quoter/pricing/QuoteDataHelper.py
@@ -3207,11 +3207,15 @@ def extract_quote_data_from_cad(
     total_total_cost = total_direct_cost + total_machine_cost + total_labor_cost
 
     # Margin and pricing
-    per_unit_margin_amount = round(per_unit_total_cost * margin_rate, 2)
-    per_unit_final_price = round(per_unit_total_cost + per_unit_margin_amount, 2)
-
+    # OPTION A (job-first): Calculate job totals first, round them, then derive per-unit
+    # This ensures per_unit × quantity = job_total exactly, avoiding rounding discrepancies
     total_margin_amount = round(total_total_cost * margin_rate, 2)
     total_final_price = round(total_total_cost + total_margin_amount, 2)
+
+    # Derive per-unit from job totals (exact division, no rounding)
+    # When displayed with 2 decimals, these will show rounded but remain mathematically consistent
+    per_unit_margin_amount = total_margin_amount / quantity
+    per_unit_final_price = total_final_price / quantity
 
     quote_data.cost_summary = CostSummary(
         # Per-unit costs


### PR DESCRIPTION
Applied job-first rounding approach consistently:
- Calculate job margin and final price first, round to 2 decimals
- Derive per-unit values as exact division (job_total / quantity)
- Ensures per_unit × quantity = job_total exactly (no cent discrepancies)

Changes:
- QuoteDataHelper.py: Switched margin/pricing calculation to job-first
- AppV7.py: Updated Quick What-If to match job-first approach

This fixes the issue where 15% margin and final price would differ by a cent between displayed job total and per-unit × quantity, especially on large quantities.